### PR TITLE
Fix for IsNan and IsInfinite

### DIFF
--- a/accelerate-llvm/src/Data/Array/Accelerate/LLVM/CodeGen/Downcast.hs
+++ b/accelerate-llvm/src/Data/Array/Accelerate/LLVM/CodeGen/Downcast.hs
@@ -190,6 +190,11 @@ instance Downcast (Instruction a) L.Instruction where
   downcast (Phi t incoming)         = L.Phi (downcast t) (downcast incoming) md
   downcast (Select _ p x y)         = L.Select (downcast p) (downcast x) (downcast y) md
   downcast (Call f attrs)           = L.Call tailcall L.C [] (downcast f) (downcast f) (downcast attrs) md
+  downcast (FCmp t p x y)           =
+    let
+        fp UNO = FP.UNO
+        fp OEQ = FP.OEQ
+    in L.FCmp (fp p) (downcast x) (downcast y) md
   downcast (Cmp t p x y)            =
     let
         fp EQ = FP.OEQ

--- a/accelerate-llvm/src/Data/Array/Accelerate/LLVM/CodeGen/Intrinsic.hs
+++ b/accelerate-llvm/src/Data/Array/Accelerate/LLVM/CodeGen/Intrinsic.hs
@@ -49,15 +49,8 @@ llvmIntrinsic =
           : (base <> "f", Label ("llvm." <> base <> ".f32"))
           : (base <> "l", Label ("llvm." <> base <> ".f128"))
           : rest
-
-      others
-          = ("isnanf", "isnan")
-          : ("isnand", "isnan")
-          : ("isinff", "isinf")
-          : ("isinfd", "isinf")
-          : []
   in
-  HashMap.fromList $ foldr floating others
+  HashMap.fromList $ foldr floating []
     [ "sqrt"
     , "powi"
     , "sin"

--- a/accelerate-llvm/src/Data/Array/Accelerate/LLVM/CodeGen/Type.hs
+++ b/accelerate-llvm/src/Data/Array/Accelerate/LLVM/CodeGen/Type.hs
@@ -115,6 +115,7 @@ instance TypeOf Instruction where
       IntToFP _ t _         -> PrimType (ScalarPrimType (NumScalarType (FloatingNumType t)))
       BitCast t _           -> PrimType (ScalarPrimType t)
       PtrCast t _           -> PrimType t
+      FCmp{}                -> type'
       Cmp{}                 -> type'
       Select t _ _ _        -> PrimType (ScalarPrimType t)
       Phi t _               -> PrimType t

--- a/accelerate-llvm/src/LLVM/AST/Type/Instruction.hs
+++ b/accelerate-llvm/src/LLVM/AST/Type/Instruction.hs
@@ -279,6 +279,13 @@ data Instruction a where
   --
   -- We treat non-scalar types as signed/unsigned integer values.
   --
+
+  FCmp          :: FloatingType a
+                -> FOrdering
+                -> Operand a
+                -> Operand a
+                -> Instruction Bool
+                
   Cmp           :: ScalarType a
                 -> Ordering
                 -> Operand a

--- a/accelerate-llvm/src/LLVM/AST/Type/Instruction/Compare.hs
+++ b/accelerate-llvm/src/LLVM/AST/Type/Instruction/Compare.hs
@@ -16,3 +16,6 @@ module LLVM.AST.Type.Instruction.Compare
 --
 data Ordering = EQ | NE | LT | LE | GT | GE
 
+-- | Ordering predicate only for floating-point comparison instructions
+--
+data FOrdering = OEQ | UNO


### PR DESCRIPTION
This is a fix for AccelerateHS/accelerate#407. The LLVM.Native backend doesn't give correct results for `IsNaN` / `IsInfinite` for floats, but works for doubles. The underlying issue is that we were calling through to the libc `isnan` and `isinfinite` functions, which don't actually have to exist based on the standard, and when they do they typically expect 64-bit calls. This wan't an issue with LLVM.PTX since we were specifying the specific float and double functions in libdevice.

As a solution, I've changed the definition of `IsNaN` and `IsInfinite` to use standard LLVM instructions rather than intrinsics. `IsNaN` is given by the LLVM `fcmp UNO x x`, a check that the value is unorderable. `IsInfinite` is given by first calculating the absolute value, and then doing an ordered equality check against positive infinity. These seem to be the standard methods (e.g. see this [LLVM discussion](https://reviews.llvm.org/D18513)).

Note this change also affects the generated code for the PTX backend.

I've done basic testing with Native and PTX on Mac, and Native on Ubuntu.

As a simple and explicit demonstration, see this code:
```
module Main where

import Data.Array.Accelerate as A
import Data.Array.Accelerate.LLVM.Native as CPU

main :: IO ()
main = do
    let floats = [0/0, -2/0, -0/0, 0.1, 1/0, 0.5, 5/0] :: [Float]
    let doubles = [0/0, -2/0, -0/0, 0.1, 1/0, 0.5, 5/0] :: [Double]
    print ("float nan", floatCount A.isNaN (fromList (Z :. 6) floats))
    print ("float inf", floatCount A.isInfinite (fromList (Z :. 6) floats))
    print ("double nan", doubleCount A.isNaN (fromList (Z :. 6) doubles))
    print ("double inf", doubleCount A.isInfinite (fromList (Z :. 6) doubles))

floatCount :: (Exp Float -> Exp Bool) -> Vector Float -> Int
floatCount f x = indexArray ((CPU.runN $ asnd . A.filter f) x) Z

doubleCount :: (Exp Double -> Exp Bool) -> Vector Double -> Int
doubleCount f x = indexArray ((CPU.runN $ asnd . A.filter f) x) Z
```

Before the fix it outputs
```
("float nan",0) -- incorrect!
("float inf",0) -- incorrect!
("double nan",2)
("double inf",2)
```

After the fix we get the correct
```
("float nan",2)
("float inf",2)
("double nan",2)
("double inf",2)
```