### PR TITLE
Fix the build with GHC 8.4

### DIFF
--- a/accelerate-llvm-native/src/Data/Array/Accelerate/LLVM/Native/Distribution/Simple/GHC.hs
+++ b/accelerate-llvm-native/src/Data/Array/Accelerate/LLVM/Native/Distribution/Simple/GHC.hs
@@ -30,7 +30,6 @@ import Distribution.Simple.Utils
 import qualified Distribution.ModuleName as ModuleName
 import Distribution.Simple.Program
 import qualified Distribution.Simple.Program.Ar    as Ar
-import qualified Distribution.Simple.Program.Ld    as Ld
 import Distribution.Simple.Program.GHC
 import Distribution.Simple.Setup
 import qualified Distribution.Simple.Setup as Cabal
@@ -359,7 +358,7 @@ buildOrReplLib forRepl verbosity numJobs pkg_descr lbi lib clbi = do
 
       whenGHCiLib $ do
         (ldProg, _) <- requireProgram verbosity ldProgram (withPrograms lbi)
-        Ld.combineObjectFiles verbosity ldProg
+        Internal.combineObjectFiles verbosity lbi ldProg
           ghciLibFilePath ghciObjFiles
 
       whenSharedLib False $

--- a/accelerate-llvm-native/src/Data/Array/Accelerate/LLVM/Native/Distribution/Simple/GHC/Internal.hs
+++ b/accelerate-llvm-native/src/Data/Array/Accelerate/LLVM/Native/Distribution/Simple/GHC/Internal.hs
@@ -19,6 +19,7 @@ module Data.Array.Accelerate.LLVM.Native.Distribution.Simple.GHC.Internal (
   getHaskellObjects,
   mkGhcOptPackages,
   profDetailLevelFlag,
+  combineObjectFiles
 
 ) where
 
@@ -28,9 +29,12 @@ import Distribution.Backpack
 import Distribution.PackageDescription as PD hiding (Flag)
 import Distribution.Simple.Compiler hiding (Flag)
 import Distribution.Simple.LocalBuildInfo
+import Distribution.Simple.Program (ConfiguredProgram)
 import Distribution.Simple.Program.GHC
+import qualified Distribution.Simple.Program.Ld as Ld
 import Distribution.Simple.Setup
 import Distribution.Simple
+import Distribution.Verbosity (Verbosity)
 import qualified Distribution.ModuleName as ModuleName
 
 import qualified Data.Map as Map
@@ -113,3 +117,10 @@ allLibModules :: Library -> ComponentLocalBuildInfo -> [ModuleName.ModuleName]
 allLibModules lib _ = libModules lib
 #endif
 
+combineObjectFiles :: Verbosity -> LocalBuildInfo -> ConfiguredProgram
+                   -> FilePath -> [FilePath] -> IO ()
+#if MIN_VERSION_Cabal(2,1,0)
+combineObjectFiles = Ld.combineObjectFiles
+#else
+combineObjectFiles v _ = Ld.combineObjectFiles v
+#endif

--- a/accelerate-llvm/src/LLVM/AST/Type/Name.hs
+++ b/accelerate-llvm/src/LLVM/AST/Type/Name.hs
@@ -17,7 +17,9 @@ module LLVM.AST.Type.Name
 
 import Data.ByteString.Short                                        ( ShortByteString )
 import Data.Data
+#if __GLASGOW_HASKELL__ >= 800
 import Data.Semigroup
+#endif
 import Data.String
 import Data.Word
 import Prelude

--- a/accelerate-llvm/src/LLVM/AST/Type/Name.hs
+++ b/accelerate-llvm/src/LLVM/AST/Type/Name.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP                #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE RoleAnnotations    #-}
 {-# OPTIONS_HADDOCK hide #-}
@@ -16,6 +17,7 @@ module LLVM.AST.Type.Name
 
 import Data.ByteString.Short                                        ( ShortByteString )
 import Data.Data
+import Data.Semigroup
 import Data.String
 import Data.Word
 import Prelude
@@ -70,6 +72,11 @@ data Label = Label {-# UNPACK #-} !ShortByteString
 
 instance IsString Label where
   fromString = Label . fromString
+
+#if __GLASGOW_HASKELL__ >= 800
+instance Semigroup Label where
+  Label x <> Label y = Label (x <> y)
+#endif
 
 instance Monoid Label where
   mempty                      = Label mempty


### PR DESCRIPTION
In order to make `accelerate-llvm` build on GHC 8.4:

* Since `Semigroup` is now a superclass of `Monoid`, some `Semigroup` classes need to be added alongside their pre-existing `Monoid` counterparts.
* The type of `combineObjectFiles` (from `Cabal`) changed, so I added a compatibility version of it to `Data.Array.Accelerate.LLVM.Native.Distribution.Simple.GHC.Internal` which does the right thing on older `Cabal`s.