### PR TITLE
Fix build with llvm-hs-pure-6.0 and bump upper bounds

### DIFF
--- a/accelerate-llvm-native/accelerate-llvm-native.cabal
+++ b/accelerate-llvm-native/accelerate-llvm-native.cabal
@@ -140,8 +140,8 @@ Library
         , ghc
         , hashable                      >= 1.0
         , libffi                        >= 0.1
-        , llvm-hs                       >= 4.1 && < 5.2
-        , llvm-hs-pure                  >= 4.1 && < 5.2
+        , llvm-hs                       >= 4.1 && < 6.1
+        , llvm-hs-pure                  >= 4.1 && < 6.1
         , mtl                           >= 2.2.1
         , template-haskell
         , time                          >= 1.4

--- a/accelerate-llvm-ptx/accelerate-llvm-ptx.cabal
+++ b/accelerate-llvm-ptx/accelerate-llvm-ptx.cabal
@@ -153,8 +153,8 @@ Library
         , file-embed                    >= 0.0.8
         , filepath                      >= 1.0
         , hashable                      >= 1.2
-        , llvm-hs                       >= 4.1 && < 5.2
-        , llvm-hs-pure                  >= 4.1 && < 5.2
+        , llvm-hs                       >= 4.1 && < 6.1
+        , llvm-hs-pure                  >= 4.1 && < 6.1
         , mtl                           >= 2.2.1
         , nvvm                          >= 0.7.5
         , pretty                        >= 1.1

--- a/accelerate-llvm/accelerate-llvm.cabal
+++ b/accelerate-llvm/accelerate-llvm.cabal
@@ -174,8 +174,8 @@ Library
         , dlist                         >= 0.6
         , exceptions                    >= 0.6
         , filepath                      >= 1.0
-        , llvm-hs                       >= 4.1 && < 5.2
-        , llvm-hs-pure                  >= 4.1 && < 5.2
+        , llvm-hs                       >= 4.1 && < 6.1
+        , llvm-hs-pure                  >= 4.1 && < 6.1
         , mtl                           >= 2.0
         , mwc-random                    >= 0.13
         , primitive                     >= 0.6

--- a/accelerate-llvm/src/Data/Array/Accelerate/LLVM/CodeGen/Downcast.hs
+++ b/accelerate-llvm/src/Data/Array/Accelerate/LLVM/CodeGen/Downcast.hs
@@ -95,7 +95,19 @@ nuw :: Bool
 nuw = False
 
 fmf :: FastMathFlags
+#if MIN_VERSION_llvm_hs_pure(6,0,0)
+fmf = FastMathFlags
+  { allowReassoc = True
+  , noNaNs = True
+  , noInfs = True
+  , noSignedZeros = True
+  , allowReciprocal = True
+  , allowContract = True
+  , approxFunc = True
+  }
+#else
 fmf = UnsafeAlgebra
+#endif
 
 md :: L.InstructionMetadata
 md = []

--- a/accelerate-llvm/src/LLVM/AST/Type/Flags.hs
+++ b/accelerate-llvm/src/LLVM/AST/Type/Flags.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 {-# OPTIONS_HADDOCK hide #-}
 -- |
@@ -34,5 +35,16 @@ instance Default NUW where
   def = UnsignedWrap
 
 instance Default FastMathFlags where
+#if MIN_VERSION_llvm_hs_pure(6,0,0)
+  def = FastMathFlags
+    { allowReassoc = True
+    , noNaNs = True
+    , noInfs = True
+    , noSignedZeros = True
+    , allowReciprocal = True
+    , allowContract = True
+    , approxFunc = True
+    }
+#else
   def = UnsafeAlgebra
-
+#endif


### PR DESCRIPTION
<!--
Hi!

Thanks for taking the time to create this pull request! You are awesome (:

The following schema may help when filing your pull request:
-->

## Description
<!--
Provide a description of the pull request here.
Try to include a general summary of the changes in the title above.
-->

Fix build with llvm-hs-pure-6.0 and bump upper bounds on `llvm-hs-pure` and `llvm-hs`.

## How has this been tested?
<!--
Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc.
-->

I’ve only tested building `accelerate-llvm` and `accelerate-llvm-native` not `accelerate-llvm-ptx` (I don’t have a Nvidia GPU). I am getting some spurious segfaults in the tests for `foldSeg` but looking at the travis logs, these don’t seem to be new.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

