### PR TITLE
Works with cuda-0.10.0.0 and nvvm-0.9.0.0

### DIFF
--- a/accelerate-llvm-ptx/accelerate-llvm-ptx.cabal
+++ b/accelerate-llvm-ptx/accelerate-llvm-ptx.cabal
@@ -146,7 +146,7 @@ Library
         , accelerate-llvm               == 1.3.*
         , bytestring                    >= 0.10.4
         , containers                    >= 0.5 && <0.6
-        , cuda                          >= 0.9
+        , cuda                          >= 0.9 && < 0.11
         , deepseq                       >= 1.3
         , directory                     >= 1.0
         , dlist                         >= 0.6
@@ -156,7 +156,7 @@ Library
         , llvm-hs                       >= 4.1 && < 6.3
         , llvm-hs-pure                  >= 4.1 && < 6.3
         , mtl                           >= 2.2.1
-        , nvvm                          >= 0.7.5
+        , nvvm                          >= 0.7.5 && < 0.10
         , pretty                        >= 1.1
         , process                       >= 1.4.3
         , template-haskell

--- a/accelerate-llvm-ptx/src/Data/Array/Accelerate/LLVM/PTX/Compile.hs
+++ b/accelerate-llvm-ptx/src/Data/Array/Accelerate/LLVM/PTX/Compile.hs
@@ -62,6 +62,7 @@ import Control.DeepSeq
 import Control.Exception
 import Control.Monad.Except
 import Control.Monad.State
+import Data.Bifunctor                                               ( first )
 import Data.ByteString                                              ( ByteString )
 import Data.ByteString.Short                                        ( ShortByteString )
 import Data.Maybe
@@ -233,7 +234,7 @@ compileModuleNVVM dev name libdevice mdl = do
   -- Lower the generated module to bitcode, then compile and link together with
   -- the shim header and libdevice library (if necessary)
   bc  <- LLVM.moduleBitcode mdl
-  ptx <- NVVM.compileModules (("",header) : (S8.unpack name,bc) : libdevice) flags
+  ptx <- NVVM.compileModules (("",header) : (name,bc) : (fmap (first S8.pack) libdevice)) flags
 
   unless (B.null (NVVM.compileLog ptx)) $ do
     Debug.traceIO Debug.dump_cc $ "llvm: " ++ B8.unpack (NVVM.compileLog ptx)

--- a/accelerate-llvm-ptx/src/Data/Array/Accelerate/LLVM/PTX/Link.hs
+++ b/accelerate-llvm-ptx/src/Data/Array/Accelerate/LLVM/PTX/Link.hs
@@ -97,7 +97,7 @@ linkFunctionQ
     -> LaunchConfig
     -> IO (Kernel, Q (TExp (Int -> Int)))
 linkFunctionQ mdl name configure = do
-  f     <- CUDA.getFun mdl (unpack name)
+  f     <- CUDA.getFun mdl name
   regs  <- CUDA.requires f CUDA.NumRegs
   ssmem <- CUDA.requires f CUDA.SharedSizeBytes
   cmem  <- CUDA.requires f CUDA.ConstSizeBytes


### PR DESCRIPTION
Makes accelerate-llvm-ptx work with with cuda-0.10.0.0 and nvvm-0.9.0.0. 
