### PR TITLE
Fix a race condition in the scheduler

### DIFF
--- a/accelerate-llvm-native/accelerate-llvm-native.cabal
+++ b/accelerate-llvm-native/accelerate-llvm-native.cabal
@@ -112,7 +112,7 @@ Library
           base                          >= 4.7 && < 4.13
         , accelerate                    == 1.3.*
         , accelerate-llvm               == 1.3.*
-        , array                         >= 0.5.3
+        , array                         >= 0.5.2
         , bytestring                    >= 0.10.4
         , cereal                        >= 0.4
         , containers                    >= 0.5 && < 0.7

--- a/accelerate-llvm-native/accelerate-llvm-native.cabal
+++ b/accelerate-llvm-native/accelerate-llvm-native.cabal
@@ -112,6 +112,7 @@ Library
           base                          >= 4.7 && < 4.13
         , accelerate                    == 1.3.*
         , accelerate-llvm               == 1.3.*
+        , array                         >= 0.5.3
         , bytestring                    >= 0.10.4
         , cereal                        >= 0.4
         , containers                    >= 0.5 && < 0.7


### PR DESCRIPTION
<!--
Hi!

Thanks for taking the time to create this pull request! You are awesome (:

The following schema may help when filing your pull request:
-->

## Description
<!--
Provide a description of the pull request here.
Try to include a general summary of the changes in the title above.
-->
We discovered a race condition which may happen with a low probability. If a worker thread tries to claim some work from the work list, and the work list is empty, then it will go to sleep after a few attempts. It goes to sleep by first clearing an MVar and then reading it, where the latter is blocking until some other threads writes to the MVar. However, if some other thread writes to the MVar between the attempt at reading from the work list and going to sleep, then the thread would never receive a wake-up signal.


## Motivation and context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->
I tried to find a way to use a single MVar for all worker threads, but that doesn't seem possible. There is always some example in which the take operation, which removes the value from the MVar, prevents some other thread from waking up (or staying awake). Hence I now use one MVar per thread.

## How has this been tested?
I have an example project which would usually stall, before this change. It does not stall after this change (at least not in the many test runs that I did). As it failed non-deterministically, caused by timing, this is probably hard to reproduce on other machines.
<!--
Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc.
-->

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
