### PR TITLE
Fix race condition in scheduler by using new MVars

### DIFF
--- a/accelerate-llvm-native/src/Data/Array/Accelerate/LLVM/Native/Execute/Scheduler.hs
+++ b/accelerate-llvm-native/src/Data/Array/Accelerate/LLVM/Native/Execute/Scheduler.hs
@@ -167,10 +167,9 @@ retireWorkers workers@Workers{..} =
 pushTasks :: Workers -> Seq Task -> IO ()
 pushTasks Workers{..} tasks = do
   mapM_ (pushL workerTaskQueue) tasks
-  var <- readIORef workerActive
-  tryPutMVar var ()
   newVar <- newEmptyMVar
-  writeIORef workerActive newVar
+  oldVar <- atomicModifyIORef' workerActive (\old -> (newVar, old))
+  putMVar oldVar ()
 
 -- Kill worker threads immediately.
 --

--- a/accelerate-llvm-native/src/Data/Array/Accelerate/LLVM/Native/Execute/Scheduler.hs
+++ b/accelerate-llvm-native/src/Data/Array/Accelerate/LLVM/Native/Execute/Scheduler.hs
@@ -89,13 +89,24 @@ schedule workers Job{..} = do
 -- will automatically sleep waiting on the signal MVar after several failed
 -- retries. Note that 'readMVar' is multiple wake up, so all threads will be
 -- efficiently woken up when new work is added via 'submit'.
+-- 
+-- The MVar is stored in an IORef. When scheduling new work, we resolve the old MVar by
+-- putting a value in it, and we put a new, at that moment unresolved, MVar in the IORef.
+-- If the queue is empty in runWorker, then we will after some attempts wait on an MVar.
+-- It is essential that we first get the MVar out of the IORef, before trying to read
+-- from the queue. If this would have been done the other way around, we could have a
+-- race condition, where new work is pushed after we tried to dequeue work and before
+-- we wait on an MVar. We then wait on the new MVar, which may cause that this thread
+-- stalls forever.
 --
 runWorker :: IORef (MVar ()) -> LinkedQueue Task -> IO ()
 runWorker activate queue = loop 0
   where
     loop :: Int16 -> IO ()
     loop !retries = do
+      -- Extract the activation MVar from the IORef, before getting work from the queue
       activateVar <- readIORef activate
+      -- Try to claim an item from the queue
       req <- tryPopR queue
       case req of
         -- The number of retries and thread delay on failure are knobs which can
@@ -109,6 +120,10 @@ runWorker activate queue = loop 0
         Nothing   -> if retries < 16
                        then loop (retries+1)
                        else do
+                         -- This thread will sleep, by waiting on the MVar (activateVar)
+                         -- we previously extracted from the IORef (activate)
+                         -- When some other thread pushes new work, it will also write to that MVar
+                         -- and this thread will wake up.
                          D.when D.dump_sched $ do
                            tid <- myThreadId
                            message $ printf "sched: %s sleeping" (show tid)
@@ -160,15 +175,22 @@ retireWorkers workers@Workers{..} =
   pushTasks workers (Seq.replicate workerCount Retire)
 
 -- Pushes tasks to the task queue.
--- Wakes up the worker threads if needed, by writing to workerActive.
+-- Wakes up the worker threads if needed, by writing to the old MVar in workerActive.
 -- We replace workerActive with a new, empty MVar, such that we can
 -- wake them up later when we again have new work.
 --
 pushTasks :: Workers -> Seq Task -> IO ()
 pushTasks Workers{..} tasks = do
+  -- Push work to the queue
   mapM_ (pushL workerTaskQueue) tasks
+  -- Create a new MVar, which we use in a later call to pushTasks to wake up the threads.
   newVar <- newEmptyMVar
+  -- Swap the MVar in the IORef workerActive, with the new MVar
+  -- This must be atomic, to prevent race conditions when two threads are adding new work.
+  -- Without the atomic, it may occur that some MVar is never resolved, causing that a worker
+  -- thread which waits on that MVar to stall.
   oldVar <- atomicModifyIORef' workerActive (\old -> (newVar, old))
+  -- Resolve the old MVar. This will wake up all threads which waited on this MVar.
   putMVar oldVar ()
 
 -- Kill worker threads immediately.


### PR DESCRIPTION
<!--
Hi!

Thanks for taking the time to create this pull request! You are awesome (:

The following schema may help when filing your pull request:
-->

## Description
<!--
Provide a description of the pull request here.
Try to include a general summary of the changes in the title above.
-->
We discovered a race condition which may happen with a low probability. If a worker thread tries to claim some work from the work list, and the work list is empty, then it will go to sleep after a few attempts. It goes to sleep by first clearing an MVar and then reading it, where the latter is blocking until some other threads writes to the MVar. However, if some other thread writes to the MVar between the attempt at reading from the work list and going to sleep, then the thread would never receive a wake-up signal.

## Motivation and context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->
A previous fix (#48) would create an MVar per thread, which had the downside that we needed to signal to multiple MVars when pushing new work. We however found a better solution, based on the fact that only one threads adds work to the queue. Before this change, worker threads would empty the MVar and then block on it. The emptying of the MVar causes these race conditions, and this appears to be the general problem of MVars, when I was trying to think of other ways to use the MVars for scheduling.

With this change, we do not empty MVars at all. Instead, we create a new MVar each time new work was added to the queue. This prevents race conditions. Worker threads cannot stall when waiting on an old MVar, as the previous MVars will all be resolved already.

## How has this been tested?
<!--
Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc.
-->
I have an example project which would usually stall, before this change. It does not stall after this change (at least not in the many test runs that I did). As it failed non-deterministically, caused by timing, this is probably hard to reproduce on other machines.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

