### PR TITLE
Refactor tuples & use representation types

### DIFF
--- a/accelerate-llvm-native/src/Data/Array/Accelerate/LLVM/Native.hs
+++ b/accelerate-llvm-native/src/Data/Array/Accelerate/LLVM/Native.hs
@@ -2,7 +2,10 @@
 {-# LANGUAGE CPP                  #-}
 {-# LANGUAGE FlexibleInstances    #-}
 {-# LANGUAGE GADTs                #-}
+{-# LANGUAGE RankNTypes           #-}
+{-# LANGUAGE ScopedTypeVariables  #-}
 {-# LANGUAGE TemplateHaskell      #-}
+{-# LANGUAGE TypeApplications     #-}
 {-# LANGUAGE TypeFamilies         #-}
 {-# LANGUAGE TypeSynonymInstances #-}
 -- |
@@ -55,18 +58,19 @@ module Data.Array.Accelerate.LLVM.Native (
 ) where
 
 -- accelerate
-import Data.Array.Accelerate.AST                                    ( PreOpenAfun(..) )
-import Data.Array.Accelerate.Array.Sugar                            ( Arrays )
+import Data.Array.Accelerate.AST                                    ( PreOpenAfun(..), arraysRepr, lhsToArraysR, liftLHS )
+import Data.Array.Accelerate.Array.Sugar                            ( Arrays, toArr, fromArr, arrays, ArrRepr )
 import Data.Array.Accelerate.Async                                  ( Async, async, wait, poll, cancel )
 import Data.Array.Accelerate.Smart                                  ( Acc )
 import Data.Array.Accelerate.Trafo
 
+import Data.Array.Accelerate.LLVM.Embed                             ( HasTypeable(..), lhsTypeable )
 import Data.Array.Accelerate.LLVM.Native.Array.Data                 ( useRemoteAsync )
 import Data.Array.Accelerate.LLVM.Native.Compile                    ( CompiledOpenAfun, compileAcc, compileAfun )
 import Data.Array.Accelerate.LLVM.Native.Embed                      ( embedOpenAcc )
 import Data.Array.Accelerate.LLVM.Native.Execute                    ( executeAcc, executeOpenAcc )
-import Data.Array.Accelerate.LLVM.Native.Execute.Async              ( Par, evalPar, get )
-import Data.Array.Accelerate.LLVM.Native.Execute.Environment        ( Val, ValR(..) )
+import Data.Array.Accelerate.LLVM.Native.Execute.Async              ( Par, evalPar, get, getArrays )
+import Data.Array.Accelerate.LLVM.Native.Execute.Environment        ( Val, ValR(..), push )
 import Data.Array.Accelerate.LLVM.Native.Link                       ( ExecOpenAfun, linkAcc, linkAfun )
 import Data.Array.Accelerate.LLVM.Native.State
 import Data.Array.Accelerate.LLVM.Native.Target
@@ -117,8 +121,8 @@ runWithIO target a = execute
       evalNative target $ do
         build <- phase "compile" elapsedS (compileAcc acc) >>= dumpStats
         exec  <- phase "link"    elapsedS (linkAcc build)
-        res   <- phase "execute" elapsedP (evalPar (executeAcc exec >>= get))
-        return res
+        res   <- phase "execute" elapsedP (evalPar (executeAcc exec >>= getArrays (arraysRepr exec)))
+        return $ toArr res
 
 
 -- | This is 'runN', specialised to an array program of one argument.
@@ -178,8 +182,8 @@ runN = runNWith defaultTarget
 
 -- | As 'runN', but execute using the specified target (thread gang).
 --
-runNWith :: Afunction f => Native -> f -> AfunctionR f
-runNWith target f = exec
+runNWith :: forall f. Afunction f => Native -> f -> AfunctionR f
+runNWith target f = go (afunctionRepr @f) afun (return Empty)
   where
     !acc  = convertAfun f
     !afun = unsafePerformIO $ do
@@ -188,18 +192,19 @@ runNWith target f = exec
                 build <- phase "compile" elapsedS (compileAfun acc) >>= dumpStats
                 link  <- phase "link"    elapsedS (linkAfun build)
                 return link
-    !exec = go afun (return Empty)
 
-    go :: ExecOpenAfun Native aenv t -> Par Native (Val aenv) -> t
-    go (Alam l) k = \arrs ->
+    go :: AfunctionRepr t (AfunctionR t) (AreprFunctionR t) -> ExecOpenAfun Native aenv (AreprFunctionR t) -> Par Native (Val aenv) -> AfunctionR t
+    go (AfunctionReprLam repr) (Alam lhs l) k = \(arrs :: a) ->
       let k' = do aenv  <- k
-                  a     <- useRemoteAsync arrs
-                  return (aenv `Push` a)
-      in go l k'
-    go (Abody b) k = unsafePerformIO . phase "execute" elapsedP . evalNative target . evalPar $ do
+                  a     <- useRemoteAsync (arrays @a) $ fromArr arrs
+                  return (aenv `push` (lhs, a))
+      in go repr l k'
+    go AfunctionReprBody (Abody b) k = unsafePerformIO . phase "execute" elapsedP . evalNative target . evalPar $ do
       aenv <- k
       res  <- executeOpenAcc b aenv
-      get res
+      arrs <- getArrays (arraysRepr b) res
+      return $ toArr arrs
+    go _ _ _ = error "The moon is hanging upside down"
 
 
 -- | As 'run1', but execute asynchronously.
@@ -215,12 +220,12 @@ run1AsyncWith = runNAsyncWith
 
 -- | As 'runN', but execute asynchronously.
 --
-runNAsync :: (Afunction f, RunAsync r, AfunctionR f ~ RunAsyncR r) => f -> r
+runNAsync :: (Afunction f, RunAsync r, AreprFunctionR f ~ RunAsyncR r) => f -> r
 runNAsync = runNAsyncWith defaultTarget
 
 -- | As 'runNWith', but execute asynchronously.
 --
-runNAsyncWith :: (Afunction f, RunAsync r, AfunctionR f ~ RunAsyncR r) => Native -> f -> r
+runNAsyncWith :: (Afunction f, RunAsync r, AreprFunctionR f ~ RunAsyncR r) => Native -> f -> r
 runNAsyncWith target f = exec
   where
     !acc  = convertAfun f
@@ -236,22 +241,23 @@ class RunAsync f where
   type RunAsyncR f
   runAsync' :: Native -> ExecOpenAfun Native aenv (RunAsyncR f) -> Par Native (Val aenv) -> f
 
-instance RunAsync b => RunAsync (a -> b) where
-  type RunAsyncR (a -> b) = a -> RunAsyncR b
+instance (Arrays a, RunAsync b) => RunAsync (a -> b) where
+  type RunAsyncR (a -> b) = ArrRepr a -> RunAsyncR b
   runAsync' _      Abody{}  _ _    = error "runAsync: function oversaturated"
-  runAsync' target (Alam l) k arrs =
+  runAsync' target (Alam lhs l) k arrs =
     let k' = do aenv  <- k
-                a     <- useRemoteAsync arrs
-                return (aenv `Push` a)
+                a     <- useRemoteAsync (lhsToArraysR lhs) $ fromArr arrs
+                return (aenv `push` (lhs, a))
     in runAsync' target l k'
 
-instance RunAsync (IO (Async b)) where
-  type RunAsyncR  (IO (Async b)) = b
+instance Arrays b => RunAsync (IO (Async b)) where
+  type RunAsyncR  (IO (Async b)) = ArrRepr b
   runAsync' _      Alam{}    _ = error "runAsync: function not fully applied"
   runAsync' target (Abody b) k = async . phase "execute" elapsedP . evalNative target . evalPar $ do
     aenv  <- k
     ans   <- executeOpenAcc b aenv
-    get ans
+    arrs  <- getArrays (arraysRepr b) ans
+    return $ toArr arrs
 
 
 -- | Stream a lazily read list of input arrays through the given program,
@@ -387,16 +393,16 @@ runQ' using target f = do
   -- directly to the body expression.
   let
       go :: Typeable aenv => CompiledOpenAfun Native aenv t -> [TH.PatQ] -> [TH.ExpQ] -> [TH.StmtQ] -> TH.ExpQ
-      go (Alam l) xs as stmts = do
+      go (Alam lhs l) xs as stmts | HasTypeable <- lhsTypeable lhs = do
         x <- TH.newName "x" -- lambda bound variable
         a <- TH.newName "a" -- local array name
         s <- TH.bindS (TH.varP a) [| useRemoteAsync $(TH.varE x) |]
-        go l (TH.varP x : xs) (TH.varE a : as) (return s : stmts)
+        go l (TH.varP x : xs) ([| ($(TH.unTypeQ $ liftLHS lhs), $(TH.varE a)) |] : as) (return s : stmts)
 
       go (Abody b) xs as stmts = do
         r <- TH.newName "r" -- result
         let
-            aenv  = foldr (\a gamma -> [| $gamma `Push` $a |]) [| Empty |] as
+            aenv  = foldr (\a gamma -> [| $gamma `push` $a |]) [| Empty |] as
             body  = embedOpenAcc defaultTarget b
         --
         TH.lamE (reverse xs)

--- a/accelerate-llvm-native/src/Data/Array/Accelerate/LLVM/Native/CodeGen/Scan.hs
+++ b/accelerate-llvm-native/src/Data/Array/Accelerate/LLVM/Native/CodeGen/Scan.hs
@@ -116,7 +116,7 @@ mkScanl'
     -> IRFun2     Native aenv (e -> e -> e)
     -> IRExp      Native aenv e
     -> MIRDelayed Native aenv (Array (sh:.Int) e)
-    -> CodeGen    Native      (IROpenAcc Native aenv (Array (sh:.Int) e, Array sh e))
+    -> CodeGen    Native      (IROpenAcc Native aenv (((), Array (sh:.Int) e), Array sh e))
 mkScanl' uid aenv combine seed arr
   | Just Refl <- matchShapeType @sh @Z
   = foldr1 (+++) <$> sequence [ mkScan'S L uid aenv combine seed arr
@@ -196,7 +196,7 @@ mkScanr'
     -> IRFun2     Native aenv (e -> e -> e)
     -> IRExp      Native aenv e
     -> MIRDelayed Native aenv (Array (sh:.Int) e)
-    -> CodeGen    Native      (IROpenAcc Native aenv (Array (sh:.Int) e, Array sh e))
+    -> CodeGen    Native      (IROpenAcc Native aenv (((), Array (sh:.Int) e), Array sh e))
 mkScanr' uid aenv combine seed arr
   | Just Refl <- matchShapeType @sh @Z
   = foldr1 (+++) <$> sequence [ mkScan'S R uid aenv combine seed arr
@@ -226,7 +226,7 @@ mkScan'Fill
     => UID
     -> Gamma          aenv
     -> IRExp   Native aenv e
-    -> CodeGen Native     (IROpenAcc Native aenv (Array (sh:.Int) e, Array sh e))
+    -> CodeGen Native     (IROpenAcc Native aenv (((), Array (sh:.Int) e), Array sh e))
 mkScan'Fill uid aenv seed =
   Safe.coerce <$> mkScanFill @sh uid aenv seed
 
@@ -324,7 +324,7 @@ mkScan'S
     -> IRFun2     Native aenv (e -> e -> e)
     -> IRExp      Native aenv e
     -> MIRDelayed Native aenv (Array (sh:.Int) e)
-    -> CodeGen    Native      (IROpenAcc Native aenv (Array (sh:.Int) e, Array sh e))
+    -> CodeGen    Native      (IROpenAcc Native aenv (((), Array (sh:.Int) e), Array sh e))
 mkScan'S dir uid aenv combine seed marr =
   let
       (start, end, paramGang) = gangParam    @DIM1
@@ -617,7 +617,7 @@ mkScan'P
     -> IRFun2     Native aenv (e -> e -> e)
     -> IRExp      Native aenv e
     -> MIRDelayed Native aenv (Vector e)
-    -> CodeGen    Native      (IROpenAcc Native aenv (Vector e, Scalar e))
+    -> CodeGen    Native      (IROpenAcc Native aenv (((), Vector e), Scalar e))
 mkScan'P dir uid aenv combine seed arr =
   foldr1 (+++) <$> sequence [ mkScan'P1 dir uid aenv combine seed arr
                             , mkScan'P2 dir uid aenv combine
@@ -638,7 +638,7 @@ mkScan'P1
     -> IRFun2     Native aenv (e -> e -> e)
     -> IRExp      Native aenv e
     -> MIRDelayed Native aenv (Vector e)
-    -> CodeGen    Native      (IROpenAcc Native aenv (Vector e, Scalar e))
+    -> CodeGen    Native      (IROpenAcc Native aenv (((), Vector e), Scalar e))
 mkScan'P1 dir uid aenv combine seed marr =
   let
       (start, end, paramGang) = gangParam    @DIM1
@@ -717,7 +717,7 @@ mkScan'P2
     -> UID
     -> Gamma          aenv
     -> IRFun2  Native aenv (e -> e -> e)
-    -> CodeGen Native      (IROpenAcc Native aenv (Vector e, Scalar e))
+    -> CodeGen Native      (IROpenAcc Native aenv (((), Vector e), Scalar e))
 mkScan'P2 dir uid aenv combine =
   let
       (start, end, paramGang) = gangParam    @DIM1
@@ -772,7 +772,7 @@ mkScan'P3
     -> UID
     -> Gamma          aenv
     -> IRFun2  Native aenv (e -> e -> e)
-    -> CodeGen Native      (IROpenAcc Native aenv (Vector e, Scalar e))
+    -> CodeGen Native      (IROpenAcc Native aenv (((), Vector e), Scalar e))
 mkScan'P3 dir uid aenv combine =
   let
       (start, end, paramGang) = gangParam    @DIM1

--- a/accelerate-llvm-native/src/Data/Array/Accelerate/LLVM/Native/Execute.hs
+++ b/accelerate-llvm-native/src/Data/Array/Accelerate/LLVM/Native/Execute.hs
@@ -36,6 +36,7 @@ import Data.Array.Accelerate.Lifetime
 import Data.Array.Accelerate.Type
 
 import Data.Array.Accelerate.LLVM.Execute
+import Data.Array.Accelerate.LLVM.Execute.Async (FutureArraysR)
 import Data.Array.Accelerate.LLVM.State
 
 import Data.Array.Accelerate.LLVM.Native.Array.Data
@@ -68,9 +69,8 @@ import Prelude                                                      hiding ( map
 import Foreign.LibFFI
 import Foreign.Ptr
 
-
-{-# SPECIALISE INLINE executeAcc     :: ExecAcc     Native      a ->             Par Native (Future a) #-}
-{-# SPECIALISE INLINE executeOpenAcc :: ExecOpenAcc Native aenv a -> Val aenv -> Par Native (Future a) #-}
+{-# SPECIALISE INLINE executeAcc     :: ExecAcc     Native      a ->             Par Native (FutureArraysR Native a) #-}
+{-# SPECIALISE INLINE executeOpenAcc :: ExecOpenAcc Native aenv a -> Val aenv -> Par Native (FutureArraysR Native a) #-}
 
 -- Array expression evaluation
 -- ---------------------------
@@ -690,12 +690,12 @@ stencilBorders sh halo = Seq.fromFunction (2 * rank @sh) face
 
 {-# INLINE aforeignOp #-}
 aforeignOp
-    :: (Arrays as, Arrays bs)
-    => String
+    :: String
+    -> ArraysR bs
     -> (as -> Par Native (Future bs))
     -> as
     -> Par Native (Future bs)
-aforeignOp name asm arr = do
+aforeignOp name _ asm arr = do
   wallBegin <- liftIO getMonotonicTime
   result    <- Debug.timed Debug.dump_exec (\wall cpu -> printf "exec: %s %s" name (Debug.elapsedP wall cpu)) (asm arr)
   wallEnd   <- liftIO getMonotonicTime

--- a/accelerate-llvm-native/src/Data/Array/Accelerate/LLVM/Native/Execute/Async.hs
+++ b/accelerate-llvm-native/src/Data/Array/Accelerate/LLVM/Native/Execute/Async.hs
@@ -17,7 +17,7 @@
 
 module Data.Array.Accelerate.LLVM.Native.Execute.Async (
 
-  Async(..), Future(..), IVar(..),
+  Async(..), Future(..), IVar(..), getArrays,
   evalPar, liftPar, putIO,
 
 ) where

--- a/accelerate-llvm-native/src/Data/Array/Accelerate/LLVM/Native/Foreign.hs
+++ b/accelerate-llvm-native/src/Data/Array/Accelerate/LLVM/Native/Foreign.hs
@@ -44,7 +44,7 @@ import Data.Typeable
 
 instance Foreign Native where
   foreignAcc (ff :: asm (a -> b))
-    | Just (ForeignAcc _ asm :: ForeignAcc (a -> b)) <- cast ff = Just asm
+    | Just (ForeignAcc _ asm :: ForeignAcc (S.ArrRepr a -> S.ArrRepr b)) <- cast ff = Just asm
     | otherwise                                                 = Nothing
 
   foreignExp (ff :: asm (x -> y))

--- a/accelerate-llvm-ptx/src/Data/Array/Accelerate/LLVM/PTX.hs
+++ b/accelerate-llvm-ptx/src/Data/Array/Accelerate/LLVM/PTX.hs
@@ -254,10 +254,10 @@ runNWith' target acc = go (afunctionRepr @f) afun (return Empty)
     go AfunctionReprBody (Abody b) k = unsafePerformIO . phase "execute" . evalPTX target . evalPar $ do
       aenv <- k
       fut  <- executeOpenAcc b aenv
-      res  <- spawn $ do
-                      ans <- getArrays (arrays @tf) fut
-                      newFull ans
-      toArr <$> copyToHostLazy (arrays @tf) res
+      --res  <- spawn $ do
+      ans <- getArrays (arrays @tf) fut
+      --                newFull ans
+      toArr <$> copyToHost (arrays @tf) ans
     go _ _ _ = error "But that's not right, oh, no, what's the story?"
 
 

--- a/accelerate-llvm-ptx/src/Data/Array/Accelerate/LLVM/PTX.hs
+++ b/accelerate-llvm-ptx/src/Data/Array/Accelerate/LLVM/PTX.hs
@@ -1,8 +1,12 @@
+{-# LANGUAGE AllowAmbiguousTypes  #-}
 {-# LANGUAGE BangPatterns         #-}
 {-# LANGUAGE CPP                  #-}
 {-# LANGUAGE FlexibleInstances    #-}
 {-# LANGUAGE GADTs                #-}
+{-# LANGUAGE RankNTypes           #-}
+{-# LANGUAGE ScopedTypeVariables  #-}
 {-# LANGUAGE TemplateHaskell      #-}
+{-# LANGUAGE TypeApplications     #-}
 {-# LANGUAGE TypeFamilies         #-}
 {-# LANGUAGE TypeSynonymInstances #-}
 -- |
@@ -51,20 +55,21 @@ module Data.Array.Accelerate.LLVM.PTX (
 ) where
 
 -- accelerate
-import Data.Array.Accelerate.AST                                    ( PreOpenAfun(..) )
-import Data.Array.Accelerate.Array.Sugar                            ( Arrays )
+import Data.Array.Accelerate.AST                                    ( PreOpenAfun(..), liftLHS, arraysRepr, lhsToArraysR )
+import Data.Array.Accelerate.Array.Sugar                            ( Arrays, ArrRepr, arrays, toArr, fromArr )
 import Data.Array.Accelerate.Async                                  ( Async, asyncBound, wait, poll, cancel )
 import Data.Array.Accelerate.Error                                  ( internalError )
 import Data.Array.Accelerate.Smart                                  ( Acc )
 import Data.Array.Accelerate.Trafo
 import Data.Array.Accelerate.Debug                                  as Debug
 
+import Data.Array.Accelerate.LLVM.Embed                             ( HasTypeable(..), lhsTypeable )
 import Data.Array.Accelerate.LLVM.PTX.Array.Data
 import Data.Array.Accelerate.LLVM.PTX.Compile
 import Data.Array.Accelerate.LLVM.PTX.Context
 import Data.Array.Accelerate.LLVM.PTX.Embed
 import Data.Array.Accelerate.LLVM.PTX.Execute
-import Data.Array.Accelerate.LLVM.PTX.Execute.Async                 ( Par, evalPar )
+import Data.Array.Accelerate.LLVM.PTX.Execute.Async                 ( Par, evalPar, getArrays, spawn, newFull )
 import Data.Array.Accelerate.LLVM.PTX.Execute.Environment
 import Data.Array.Accelerate.LLVM.PTX.Link
 import Data.Array.Accelerate.LLVM.PTX.State
@@ -129,7 +134,7 @@ runAsyncWith target a = asyncBound (runWithIO target a)
 runIO :: Arrays a => Acc a -> IO a
 runIO a = withPool defaultTargetPool (\target -> runWithIO target a)
 
-runWithIO :: Arrays a => PTX -> Acc a -> IO a
+runWithIO :: forall a. Arrays a => PTX -> Acc a -> IO a
 runWithIO target a = execute
   where
     !acc    = convertAcc a
@@ -138,8 +143,10 @@ runWithIO target a = execute
       evalPTX target $ do
         build <- phase "compile" (compileAcc acc) >>= dumpStats
         exec  <- phase "link"    (linkAcc build)
-        res   <- phase "execute" (evalPar (executeAcc exec >>= copyToHostLazy))
-        return res
+        res   <- phase "execute" (evalPar (executeAcc exec
+                                            >>= (\fut -> spawn $ getArrays (arrays @a) fut >>= newFull)
+                                            >>= copyToHostLazy (arrays @a)))
+        return $ toArr res
 
 
 -- | This is 'runN', specialised to an array program of one argument.
@@ -201,7 +208,7 @@ run1With = runNWith
 -- See also 'runQ', which compiles the Accelerate program at _Haskell_ compile
 -- time, thus eliminating the runtime overhead altogether.
 --
-runN :: Afunction f => f -> AfunctionR f
+runN :: forall f. Afunction f => f -> AfunctionR f
 runN f = exec
   where
     !acc  = convertAfun f
@@ -217,19 +224,19 @@ runN f = exec
     -- depending on which GPU gets scheduled.
     --
     !afun = flip map (unmanaged defaultTargetPool)
-          $ \target -> (ptxContext target, runNWith' target acc)
+          $ \target -> (ptxContext target, runNWith' @f target acc)
 
 
 -- | As 'runN', but execute using the specified target device.
 --
-runNWith :: Afunction f => PTX -> f -> AfunctionR f
+runNWith :: forall f. Afunction f => PTX -> f -> AfunctionR f
 runNWith target f = exec
   where
     !acc  = convertAfun f
-    !exec = runNWith' target acc
+    !exec = runNWith' @f target acc
 
-runNWith' :: PTX -> DelayedAfun f -> f
-runNWith' target acc = exec
+runNWith' :: forall f. Afunction f => PTX -> DelayedAfun (AreprFunctionR f) -> AfunctionR f
+runNWith' target acc = go (afunctionRepr @f) afun (return Empty)
   where
     !afun = unsafePerformIO $ do
               dumpGraph acc
@@ -237,18 +244,21 @@ runNWith' target acc = exec
                 build <- phase "compile" (compileAfun acc) >>= dumpStats
                 link  <- phase "link"    (linkAfun build)
                 return link
-    !exec = go afun (return Empty)
 
-    go :: ExecOpenAfun PTX aenv t -> Par PTX (Val aenv) -> t
-    go (Alam l) k = \ !arrs ->
+    go :: forall aenv t tf trepr. AfunctionRepr t tf trepr -> ExecOpenAfun PTX aenv trepr -> Par PTX (Val aenv) -> tf
+    go (AfunctionReprLam repr) (Alam lhs l) k = \ !arrs ->
       let k' = do aenv <- k
-                  a    <- useRemoteAsync arrs
-                  return (aenv `Push` a)
-      in go l k'
-    go (Abody b) k = unsafePerformIO . phase "execute" . evalPTX target . evalPar $ do
+                  a    <- useRemoteAsync (lhsToArraysR lhs) $ fromArr arrs
+                  return (aenv `push` (lhs, a))
+      in go repr l k'
+    go AfunctionReprBody (Abody b) k = unsafePerformIO . phase "execute" . evalPTX target . evalPar $ do
       aenv <- k
-      res  <- executeOpenAcc b aenv
-      copyToHostLazy res
+      fut  <- executeOpenAcc b aenv
+      res  <- spawn $ do
+                      ans <- getArrays (arrays @tf) fut
+                      newFull ans
+      toArr <$> copyToHostLazy (arrays @tf) res
+    go _ _ _ = error "But that's not right, oh, no, what's the story?"
 
 
 -- | As 'run1', but the computation is executed asynchronously.
@@ -264,7 +274,7 @@ run1AsyncWith = runNAsyncWith
 
 -- | As 'runN', but execute asynchronously.
 --
-runNAsync :: (Afunction f, RunAsync r, AfunctionR f ~ RunAsyncR r) => f -> r
+runNAsync :: (Afunction f, RunAsync r, AreprFunctionR f ~ RunAsyncR r) => f -> r
 runNAsync f = exec
   where
     !acc  = convertAfun f
@@ -277,7 +287,7 @@ runNAsync f = exec
 
 -- | As 'runNWith', but execute asynchronously.
 --
-runNAsyncWith :: (Afunction f, RunAsync r, AfunctionR f ~ RunAsyncR r) => PTX -> f -> r
+runNAsyncWith :: (Afunction f, RunAsync r, AreprFunctionR f ~ RunAsyncR r) => PTX -> f -> r
 runNAsyncWith target f = exec
   where
     !acc  = convertAfun f
@@ -298,22 +308,23 @@ class RunAsync f where
   type RunAsyncR f
   runAsync' :: PTX -> ExecOpenAfun PTX aenv (RunAsyncR f) -> Par PTX (Val aenv) -> f
 
-instance RunAsync b => RunAsync (a -> b) where
-  type RunAsyncR (a -> b) = a -> RunAsyncR b
+instance (Arrays a, RunAsync b) => RunAsync (a -> b) where
+  type RunAsyncR (a -> b) = ArrRepr a -> RunAsyncR b
   runAsync' _      Abody{}  _ _     = error "runAsync: function oversaturated"
-  runAsync' target (Alam l) k !arrs =
+  runAsync' target (Alam lhs l) k !arrs =
     let k' = do aenv  <- k
-                a     <- useRemoteAsync arrs
-                return (aenv `Push` a)
+                a     <- useRemoteAsync (arrays @a) $ fromArr arrs
+                return (aenv `push` (lhs, a))
     in runAsync' target l k'
 
-instance RunAsync (IO (Async b)) where
-  type RunAsyncR (IO (Async b)) = b
+instance Arrays b => RunAsync (IO (Async b)) where
+  type RunAsyncR (IO (Async b)) = ArrRepr b
   runAsync' _      Alam{}    _ = error "runAsync: function not fully applied"
   runAsync' target (Abody b) k = asyncBound . phase "execute" . evalPTX target . evalPar $ do
     aenv <- k
-    res  <- executeOpenAcc b aenv
-    copyToHostLazy res
+    ans  <- executeOpenAcc b aenv
+    arrs  <- getArrays (arraysRepr b) ans
+    return $ toArr arrs
 
 
 -- | Stream a lazily read list of input arrays through the given program,
@@ -455,16 +466,16 @@ runQ'_ using k f = do
                    phase "compile" (compileAfun acc) >>= dumpStats
   let
       go :: Typeable aenv => CompiledOpenAfun PTX aenv t -> [TH.PatQ] -> [TH.ExpQ] -> [TH.StmtQ] -> TH.ExpQ
-      go (Alam l) xs as stmts = do
+      go (Alam lhs l) xs as stmts | HasTypeable <- lhsTypeable lhs = do
         x <- TH.newName "x" -- lambda bound variable
         a <- TH.newName "a" -- local array name
         s <- TH.bindS (TH.varP a) [| useRemoteAsync $(TH.varE x) |]
-        go l (TH.bangP (TH.varP x) : xs) (TH.varE a : as) (return s : stmts)
+        go l (TH.bangP (TH.varP x) : xs) ([| ($(TH.unTypeQ $ liftLHS lhs), fromArr $(TH.varE a)) |] : as) (return s : stmts)
 
       go (Abody b) xs as stmts = do
         r <- TH.newName "r" -- result
         let
-            aenv  = foldr (\a gamma -> [| $gamma `Push` $a |] ) [| Empty |] as
+            aenv  = foldr (\a gamma -> [| $gamma `push` $a |] ) [| Empty |] as
             body  = embedOpenAcc defaultTarget b
         --
         TH.lamE (reverse xs)

--- a/accelerate-llvm-ptx/src/Data/Array/Accelerate/LLVM/PTX/Array/Data.hs
+++ b/accelerate-llvm-ptx/src/Data/Array/Accelerate/LLVM/PTX/Array/Data.hs
@@ -101,10 +101,10 @@ instance Remote PTX where
 --
 {-# INLINEABLE copyToHostLazy #-}
 copyToHostLazy
-    :: Arrays arrs
-    => Future arrs
+    :: ArraysR arrs
+    -> Future arrs
     -> Par PTX arrs
-copyToHostLazy future@(Future ref) = do
+copyToHostLazy repr future@(Future ref) = do
   ptx   <- gets llvmTarget
   arrs  <- liftIO $ do
     ivar  <- readIORef ref
@@ -113,7 +113,7 @@ copyToHostLazy future@(Future ref) = do
                Pending _ _ a  -> return a
                Empty          -> $internalError "copyToHostLazy" "blocked on an IVar"
     --
-    runArrays arrs $ \(Array sh adata) ->
+    runArrays repr arrs $ \(Array sh adata) ->
       let
           -- Note: [Lazy device-host transfers]
           --

--- a/accelerate-llvm-ptx/src/Data/Array/Accelerate/LLVM/PTX/Array/Data.hs
+++ b/accelerate-llvm-ptx/src/Data/Array/Accelerate/LLVM/PTX/Array/Data.hs
@@ -102,142 +102,143 @@ instance Remote PTX where
 {-# INLINEABLE copyToHostLazy #-}
 copyToHostLazy
     :: ArraysR arrs
-    -> Future arrs
+    -> FutureArraysR PTX arrs
     -> Par PTX arrs
-copyToHostLazy repr future@(Future ref) = do
-  ptx   <- gets llvmTarget
-  arrs  <- liftIO $ do
-    ivar  <- readIORef ref
-    arrs  <- case ivar of -- peek at the underlying array
-               Full a         -> return a
-               Pending _ _ a  -> return a
-               Empty          -> $internalError "copyToHostLazy" "blocked on an IVar"
+copyToHostLazy ArraysRunit () = return ()
+copyToHostLazy (ArraysRpair r1 r2) (f1, f2) = do
+  a1 <- copyToHostLazy r1 f1
+  a2 <- copyToHostLazy r2 f2
+  return (a1, a2)
+copyToHostLazy (ArraysRarray) future@(Future ref) = do
+  ptx <- gets llvmTarget
+  liftIO $ do
+    ivar <- readIORef ref
+    (Array sh adata) <- case ivar of
+      Full a        -> return a
+      Pending _ _ a -> return a
+      Empty         -> $internalError "copyToHostLazy" "blocked on an IVar"
+    -- Note: [Lazy device-host transfers]
     --
-    runArrays repr arrs $ \(Array sh adata) ->
-      let
-          -- Note: [Lazy device-host transfers]
-          --
-          -- This needs must be non-strict at the leaves of the datatype (that
-          -- is, the UniqueArray pointers). This means we can traverse the
-          -- ArrayData constructors (in particular, the spine defined by Unit
-          -- and Pair) until we reach the array we care about, without forcing
-          -- the other fields.
-          --
-          -- https://github.com/AccelerateHS/accelerate/issues/437
-          --
-          -- Furthermore, we only want to transfer the data if the host pointer
-          -- is currently unevaluated. This situation can occur for example if
-          -- the argument to 'use' or 'unit' is returned as part of the result
-          -- of a 'run'. Peek at GHC's underlying closure representation and
-          -- check whether the pointer is a thunk, and only initiate the
-          -- transfer if so.
-          --
-          -- XXX: The current approach of checking the heap representation
-          -- (function 'evaluated' below) is not particularly reliable. We
-          -- should improve this situation somehow.
-          --    -- TLM 2019-06-06
-          --
-          peekR :: (ArrayElt e, ArrayPtrs e ~ Ptr a, Storable a, Typeable a, Typeable e)
-                => ArrayData e
-                -> UniqueArray a
-                -> Int
-                -> IO (UniqueArray a)
-          peekR ad (UniqueArray uid (Lifetime lft weak fp)) n = unsafeInterleaveIO $ do
-            ok  <- evaluated fp
-            fp' <- if ok
-                     then return fp
-                     else unsafeInterleaveIO . evalPTX ptx . evalPar $ do
-                            !_ <- get future -- stream synchronisation
-                            !_ <- block =<< Prim.peekArrayAsync n ad
-                            return fp
-            --
-            return $ UniqueArray uid (Lifetime lft weak fp')
+    -- This needs must be non-strict at the leaves of the datatype (that
+    -- is, the UniqueArray pointers). This means we can traverse the
+    -- ArrayData constructors (in particular, the spine defined by Unit
+    -- and Pair) until we reach the array we care about, without forcing
+    -- the other fields.
+    --
+    -- https://github.com/AccelerateHS/accelerate/issues/437
+    --
+    -- Furthermore, we only want to transfer the data if the host pointer
+    -- is currently unevaluated. This situation can occur for example if
+    -- the argument to 'use' or 'unit' is returned as part of the result
+    -- of a 'run'. Peek at GHC's underlying closure representation and
+    -- check whether the pointer is a thunk, and only initiate the
+    -- transfer if so.
+    --
+    -- XXX: The current approach of checking the heap representation
+    -- (function 'evaluated' below) is not particularly reliable. We
+    -- should improve this situation somehow.
+    --    -- TLM 2019-06-06
+    --
 
-          -- Check that the argument is evaluated to normal form. In particular
-          -- we are only concerned with the array payload (ForeignPtr).
-          --
-          evaluated :: a -> IO Bool
+    let
+      peekR :: (ArrayElt e, ArrayPtrs e ~ Ptr a, Storable a, Typeable a, Typeable e)
+            => ArrayData e
+            -> UniqueArray a
+            -> Int
+            -> IO (UniqueArray a)
+      peekR ad (UniqueArray uid (Lifetime lft weak fp)) n = unsafeInterleaveIO $ do
+        ok  <- evaluated fp
+        fp' <- if ok
+                  then return fp
+                  else unsafeInterleaveIO . evalPTX ptx . evalPar $ do
+                        !_ <- get future -- stream synchronisation
+                        !_ <- block =<< Prim.peekArrayAsync n ad
+                        return fp
+        --
+        return $ UniqueArray uid (Lifetime lft weak fp')
+
+      -- Check that the argument is evaluated to normal form. In particular
+      -- we are only concerned with the array payload (ForeignPtr).
+      --
+      evaluated :: a -> IO Bool
 #if __GLASGOW_HASKELL__ >= 806
-          evaluated x = do
-            c <- getClosureData x
-            case c of
-              ThunkClosure{}        -> return False
-              ArrWordsClosure{}     -> return True                      -- ByteArray#
-              ConstrClosure{..}     -> and <$> mapM evaluated ptrArgs   -- a data constructor
-              BlackholeClosure{..}  -> evaluated indirectee             -- evaluated by another thread (check if this is just an indirection?)
-              MutVarClosure{..}     -> evaluated var                    -- in case this is not a PlainForeignPtr
-              _                     -> do
-                Debug.when Debug.verbose $
-                  Debug.traceIO Debug.dump_gc $
-                    printf "copyToHostLazy encountered: %s" (show c)
-                return False
+      evaluated x = do
+        c <- getClosureData x
+        case c of
+          ThunkClosure{}        -> return False
+          ArrWordsClosure{}     -> return True                      -- ByteArray#
+          ConstrClosure{..}     -> and <$> mapM evaluated ptrArgs   -- a data constructor
+          BlackholeClosure{..}  -> evaluated indirectee             -- evaluated by another thread (check if this is just an indirection?)
+          MutVarClosure{..}     -> evaluated var                    -- in case this is not a PlainForeignPtr
+          _                     -> do
+            Debug.when Debug.verbose $
+              Debug.traceIO Debug.dump_gc $
+                printf "copyToHostLazy encountered: %s" (show c)
+            return False
 #else
 #if UNBOXED_TUPLES
-          evaluated x =
-            case unpackClosure# x of
-              (# iptr, ptrs, _ #) -> do
-                  let iptr0 = Ptr iptr
-                  let iptr1
-                        | ghciTablesNextToCode = iptr0
-                        | otherwise            = iptr0 `plusPtr` negate wORD_SIZE
-                  itbl <- peekItbl iptr1
-                  case tipe itbl of
-                    ARR_WORDS                                     -> return True
-                    i | i >= THUNK  && i < THUNK_SELECTOR         -> return False
-                    i | i >= CONSTR && i <= CONSTR_NOCAF          -> and <$> mapM evaluated (dumpArray# ptrs)
-                    i | i == MUT_VAR_CLEAN || i == MUT_VAR_DIRTY  -> evaluated (headArray# ptrs)
-                    BLACKHOLE                                     -> evaluated (headArray# ptrs)
-                    _                                             -> return False
+      evaluated x =
+        case unpackClosure# x of
+          (# iptr, ptrs, _ #) -> do
+              let iptr0 = Ptr iptr
+              let iptr1
+                    | ghciTablesNextToCode = iptr0
+                    | otherwise            = iptr0 `plusPtr` negate wORD_SIZE
+              itbl <- peekItbl iptr1
+              case tipe itbl of
+                ARR_WORDS                                     -> return True
+                i | i >= THUNK  && i < THUNK_SELECTOR         -> return False
+                i | i >= CONSTR && i <= CONSTR_NOCAF          -> and <$> mapM evaluated (dumpArray# ptrs)
+                i | i == MUT_VAR_CLEAN || i == MUT_VAR_DIRTY  -> evaluated (headArray# ptrs)
+                BLACKHOLE                                     -> evaluated (headArray# ptrs)
+                _                                             -> return False
 
-          wORD_SIZE = sizeOf (undefined::Word)
+      wORD_SIZE = sizeOf (undefined::Word)
 
-          -- using indexArray# makes sure that the 'Any' is looked up without
-          -- evaluating the value itself. This is not possible with Data.Array.!
-          --
-          dumpArray# :: Array# Any -> [Any]
-          dumpArray# arr# = go 0#
-            where
-              l#    = sizeofArray# arr#
-              go i# = case i# <# l# of
-                        0# -> []
-                        _  -> case indexArray# arr# i# of
-                                (# h #) -> h : go (i# +# 1#)
+      -- using indexArray# makes sure that the 'Any' is looked up without
+      -- evaluating the value itself. This is not possible with Data.Array.!
+      --
+      dumpArray# :: Array# Any -> [Any]
+      dumpArray# arr# = go 0#
+        where
+          l#    = sizeofArray# arr#
+          go i# = case i# <# l# of
+                    0# -> []
+                    _  -> case indexArray# arr# i# of
+                            (# h #) -> h : go (i# +# 1#)
 
-          headArray# :: Array# Any -> Any
-          headArray# arr# =
-            case indexArray# arr# 0# of
-              (# h #) -> h
+      headArray# :: Array# Any -> Any
+      headArray# arr# =
+        case indexArray# arr# 0# of
+          (# h #) -> h
 #else
-          evaluated _ =
-            return False
+      evaluated _ =
+        return False
 #endif
 #endif
 
-          runR :: ArrayEltR e -> ArrayData e -> Int -> IO (ArrayData e)
-          runR ArrayEltRunit               AD_Unit             !_ = return AD_Unit
-          runR (ArrayEltRpair !aeR2 !aeR1) (AD_Pair !ad2 !ad1) !n = AD_Pair   <$> runR aeR2 ad2 n <*> runR aeR1 ad1 n
-          runR (ArrayEltRvec  !aeR)        (AD_Vec w# !ad)     !n = AD_Vec w# <$> runR aeR ad (I# w# * n)
-          --
-          runR ArrayEltRint    ad@(AD_Int    ua) !n = AD_Int    <$> peekR ad ua n
-          runR ArrayEltRint8   ad@(AD_Int8   ua) !n = AD_Int8   <$> peekR ad ua n
-          runR ArrayEltRint16  ad@(AD_Int16  ua) !n = AD_Int16  <$> peekR ad ua n
-          runR ArrayEltRint32  ad@(AD_Int32  ua) !n = AD_Int32  <$> peekR ad ua n
-          runR ArrayEltRint64  ad@(AD_Int64  ua) !n = AD_Int64  <$> peekR ad ua n
-          runR ArrayEltRword   ad@(AD_Word   ua) !n = AD_Word   <$> peekR ad ua n
-          runR ArrayEltRword8  ad@(AD_Word8  ua) !n = AD_Word8  <$> peekR ad ua n
-          runR ArrayEltRword16 ad@(AD_Word16 ua) !n = AD_Word16 <$> peekR ad ua n
-          runR ArrayEltRword32 ad@(AD_Word32 ua) !n = AD_Word32 <$> peekR ad ua n
-          runR ArrayEltRword64 ad@(AD_Word64 ua) !n = AD_Word64 <$> peekR ad ua n
-          runR ArrayEltRhalf   ad@(AD_Half   ua) !n = AD_Half   <$> peekR ad ua n
-          runR ArrayEltRfloat  ad@(AD_Float  ua) !n = AD_Float  <$> peekR ad ua n
-          runR ArrayEltRdouble ad@(AD_Double ua) !n = AD_Double <$> peekR ad ua n
-          runR ArrayEltRbool   ad@(AD_Bool   ua) !n = AD_Bool   <$> peekR ad ua n
-          runR ArrayEltRchar   ad@(AD_Char   ua) !n = AD_Char   <$> peekR ad ua n
-      in
-      Array sh <$> runR arrayElt adata (R.size sh)
-  --
-  return arrs
-
+      runR :: ArrayEltR e -> ArrayData e -> Int -> IO (ArrayData e)
+      runR ArrayEltRunit               AD_Unit             !_ = return AD_Unit
+      runR (ArrayEltRpair !aeR2 !aeR1) (AD_Pair !ad2 !ad1) !n = AD_Pair   <$> runR aeR2 ad2 n <*> runR aeR1 ad1 n
+      runR (ArrayEltRvec  !aeR)        (AD_Vec w# !ad)     !n = AD_Vec w# <$> runR aeR ad (I# w# * n)
+      --
+      runR ArrayEltRint    ad@(AD_Int    ua) !n = AD_Int    <$> peekR ad ua n
+      runR ArrayEltRint8   ad@(AD_Int8   ua) !n = AD_Int8   <$> peekR ad ua n
+      runR ArrayEltRint16  ad@(AD_Int16  ua) !n = AD_Int16  <$> peekR ad ua n
+      runR ArrayEltRint32  ad@(AD_Int32  ua) !n = AD_Int32  <$> peekR ad ua n
+      runR ArrayEltRint64  ad@(AD_Int64  ua) !n = AD_Int64  <$> peekR ad ua n
+      runR ArrayEltRword   ad@(AD_Word   ua) !n = AD_Word   <$> peekR ad ua n
+      runR ArrayEltRword8  ad@(AD_Word8  ua) !n = AD_Word8  <$> peekR ad ua n
+      runR ArrayEltRword16 ad@(AD_Word16 ua) !n = AD_Word16 <$> peekR ad ua n
+      runR ArrayEltRword32 ad@(AD_Word32 ua) !n = AD_Word32 <$> peekR ad ua n
+      runR ArrayEltRword64 ad@(AD_Word64 ua) !n = AD_Word64 <$> peekR ad ua n
+      runR ArrayEltRhalf   ad@(AD_Half   ua) !n = AD_Half   <$> peekR ad ua n
+      runR ArrayEltRfloat  ad@(AD_Float  ua) !n = AD_Float  <$> peekR ad ua n
+      runR ArrayEltRdouble ad@(AD_Double ua) !n = AD_Double <$> peekR ad ua n
+      runR ArrayEltRbool   ad@(AD_Bool   ua) !n = AD_Bool   <$> peekR ad ua n
+      runR ArrayEltRchar   ad@(AD_Char   ua) !n = AD_Char   <$> peekR ad ua n
+    
+    Array sh <$> runR arrayElt adata (R.size sh)
 
 -- | Clone an array into a newly allocated array on the device.
 --

--- a/accelerate-llvm-ptx/src/Data/Array/Accelerate/LLVM/PTX/CodeGen/Scan.hs
+++ b/accelerate-llvm-ptx/src/Data/Array/Accelerate/LLVM/PTX/CodeGen/Scan.hs
@@ -127,7 +127,7 @@ mkScanl'
     -> IRFun2     PTX aenv (e -> e -> e)
     -> IRExp      PTX aenv e
     -> MIRDelayed PTX aenv (Array (sh:.Int) e)
-    -> CodeGen    PTX      (IROpenAcc PTX aenv (Array (sh:.Int) e, Array sh e))
+    -> CodeGen    PTX      (IROpenAcc PTX aenv (((), Array (sh:.Int) e), Array sh e))
 mkScanl' aenv combine seed arr
   | Just Refl <- matchShapeType @sh @Z
   = foldr1 (+++) <$> sequence [ mkScan'AllP1 L aenv combine seed arr
@@ -208,7 +208,7 @@ mkScanr'
     -> IRFun2     PTX aenv (e -> e -> e)
     -> IRExp      PTX aenv e
     -> MIRDelayed PTX aenv (Array (sh:.Int) e)
-    -> CodeGen    PTX      (IROpenAcc PTX aenv (Array (sh:.Int) e, Array sh e))
+    -> CodeGen    PTX      (IROpenAcc PTX aenv (((), Array (sh:.Int) e), Array sh e))
 mkScanr' aenv combine seed arr
   | Just Refl <- matchShapeType @sh @Z
   = foldr1 (+++) <$> sequence [ mkScan'AllP1 R aenv combine seed arr
@@ -550,7 +550,7 @@ mkScan'AllP1
     -> IRFun2     PTX aenv (e -> e -> e)
     -> IRExp      PTX aenv e
     -> MIRDelayed PTX aenv (Vector e)
-    -> CodeGen    PTX      (IROpenAcc PTX aenv (Vector e, Scalar e))
+    -> CodeGen    PTX      (IROpenAcc PTX aenv (((), Vector e), Scalar e))
 mkScan'AllP1 dir aenv combine seed marr = do
   dev <- liftCodeGen $ gets ptxDeviceProperties
   --
@@ -660,7 +660,7 @@ mkScan'AllP2
     => Direction
     -> Gamma aenv
     -> IRFun2 PTX aenv (e -> e -> e)
-    -> CodeGen PTX (IROpenAcc PTX aenv (Vector e, Scalar e))
+    -> CodeGen PTX (IROpenAcc PTX aenv (((), Vector e), Scalar e))
 mkScan'AllP2 dir aenv combine = do
   dev <- liftCodeGen $ gets ptxDeviceProperties
   --
@@ -766,7 +766,7 @@ mkScan'AllP3
     => Direction
     -> Gamma aenv                                   -- ^ array environment
     -> IRFun2 PTX aenv (e -> e -> e)                -- ^ combination function
-    -> CodeGen PTX (IROpenAcc PTX aenv (Vector e, Scalar e))
+    -> CodeGen PTX (IROpenAcc PTX aenv (((), Vector e), Scalar e))
 mkScan'AllP3 dir aenv combine = do
   dev <- liftCodeGen $ gets ptxDeviceProperties
   --
@@ -1047,7 +1047,7 @@ mkScan'Dim
     -> IRFun2     PTX aenv (e -> e -> e)            -- ^ combination function
     -> IRExp      PTX aenv e                        -- ^ seed element
     -> MIRDelayed PTX aenv (Array (sh:.Int) e)      -- ^ input data
-    -> CodeGen    PTX      (IROpenAcc PTX aenv (Array (sh:.Int) e, Array sh e))
+    -> CodeGen    PTX      (IROpenAcc PTX aenv (((), Array (sh:.Int) e), Array sh e))
 mkScan'Dim dir aenv combine seed marr = do
   dev <- liftCodeGen $ gets ptxDeviceProperties
   --
@@ -1242,7 +1242,7 @@ mkScan'Fill
     :: forall aenv sh e. (Shape sh, Elt e)
     => Gamma aenv
     -> IRExp PTX aenv e
-    -> CodeGen PTX (IROpenAcc PTX aenv (Array (sh:.Int) e, Array sh e))
+    -> CodeGen PTX (IROpenAcc PTX aenv (((), Array (sh:.Int) e), Array sh e))
 mkScan'Fill aenv seed =
   Safe.coerce <$> mkGenerate @_ @sh aenv (IRFun1 (const seed))
 

--- a/accelerate-llvm-ptx/src/Data/Array/Accelerate/LLVM/PTX/Execute.hs
+++ b/accelerate-llvm-ptx/src/Data/Array/Accelerate/LLVM/PTX/Execute.hs
@@ -62,8 +62,8 @@ import Text.Printf                                              ( printf )
 import Prelude                                                  hiding ( exp, map, sum, scanl, scanr )
 
 
-{-# SPECIALISE INLINE executeAcc     :: ExecAcc     PTX      a ->             Par PTX (Future a) #-}
-{-# SPECIALISE INLINE executeOpenAcc :: ExecOpenAcc PTX aenv a -> Val aenv -> Par PTX (Future a) #-}
+{-# SPECIALISE INLINE executeAcc     :: ExecAcc     PTX      a ->             Par PTX (FutureArraysR PTX a) #-}
+{-# SPECIALISE INLINE executeOpenAcc :: ExecOpenAcc PTX aenv a -> Val aenv -> Par PTX (FutureArraysR PTX a) #-}
 
 -- Array expression evaluation
 -- ---------------------------
@@ -696,12 +696,12 @@ stencilBorders sh halo = [ face i | i <- [0 .. (2 * rank @sh - 1)] ]
 --
 {-# INLINE aforeignOp #-}
 aforeignOp
-    :: (Arrays as, Arrays bs)
-    => String
+    :: String
+    -> ArraysR bs
     -> (as -> Par PTX (Future bs))
     -> as
     -> Par PTX (Future bs)
-aforeignOp name asm arr = do
+aforeignOp name _ asm arr = do
   stream <- asks ptxStream
   Debug.monitorProcTime query msg (Just (unsafeGetValue stream)) (asm arr)
   where

--- a/accelerate-llvm-ptx/src/Data/Array/Accelerate/LLVM/PTX/Foreign.hs
+++ b/accelerate-llvm-ptx/src/Data/Array/Accelerate/LLVM/PTX/Foreign.hs
@@ -52,8 +52,8 @@ import Data.Typeable
 
 instance Foreign PTX where
   foreignAcc (ff :: asm (a -> b))
-    | Just (ForeignAcc _ asm :: ForeignAcc (a -> b)) <- cast ff = Just asm
-    | otherwise                                                 = Nothing
+    | Just (ForeignAcc _ asm :: ForeignAcc (S.ArrRepr a -> S.ArrRepr b)) <- cast ff = Just asm
+    | otherwise                                                                     = Nothing
 
   foreignExp (ff :: asm (x -> y))
     | Just (ForeignExp _ asm :: ForeignExp (x -> y)) <- cast ff = Just asm

--- a/accelerate-llvm/src/Data/Array/Accelerate/LLVM/Array/Data.hs
+++ b/accelerate-llvm/src/Data/Array/Accelerate/LLVM/Array/Data.hs
@@ -1,9 +1,11 @@
-{-# LANGUAGE BangPatterns        #-}
-{-# LANGUAGE GADTs               #-}
-{-# LANGUAGE MagicHash           #-}
-{-# LANGUAGE RankNTypes          #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications    #-}
+{-# LANGUAGE BangPatterns         #-}
+{-# LANGUAGE GADTs                #-}
+{-# LANGUAGE MagicHash            #-}
+{-# LANGUAGE RankNTypes           #-}
+{-# LANGUAGE ScopedTypeVariables  #-}
+{-# LANGUAGE TypeApplications     #-}
+{-# LANGUAGE TypeFamilies         #-}
+{-# LANGUAGE TypeSynonymInstances #-}
 {-# OPTIONS_HADDOCK hide #-}
 -- |
 -- Module      : Data.Array.Accelerate.LLVM.Array.Data
@@ -107,9 +109,9 @@ class Async arch => Remote arch where
   -- of multiple memcpy engines.
   --
   {-# INLINE useRemoteAsync #-}
-  useRemoteAsync :: Arrays arrs => arrs -> Par arch (FutureR arch arrs)
-  useRemoteAsync arrs =
-    runArraysAsync arrs $ \arr ->
+  useRemoteAsync :: ArraysR arrs -> arrs -> Par arch (FutureArraysR arch arrs)
+  useRemoteAsync repr arrs =
+    runArraysAsync repr arrs $ \arr ->
       let n = size (shape arr)
       in  runArrayAsync arr $ \m ad ->
             useRemoteR (n*m) ad
@@ -117,9 +119,9 @@ class Async arch => Remote arch where
   -- | Upload an existing array to the remote device, asynchronously.
   --
   {-# INLINE copyToRemoteAsync #-}
-  copyToRemoteAsync :: Arrays arrs => arrs -> Par arch (FutureR arch arrs)
-  copyToRemoteAsync arrs =
-    runArraysAsync arrs $ \arr ->
+  copyToRemoteAsync :: ArraysR arrs -> arrs -> Par arch (FutureArraysR arch arrs)
+  copyToRemoteAsync repr arrs =
+    runArraysAsync repr arrs $ \arr ->
       let n = size (shape arr)
       in  runArrayAsync arr $ \m ad ->
             copyToRemoteR (n*m) ad
@@ -127,9 +129,9 @@ class Async arch => Remote arch where
   -- | Copy an array from the remote device to the host, asynchronously
   --
   {-# INLINE copyToHostAsync #-}
-  copyToHostAsync :: Arrays arrs => arrs -> Par arch (FutureR arch arrs)
-  copyToHostAsync arrs =
-    runArraysAsync arrs $ \arr ->
+  copyToHostAsync :: ArraysR arrs -> arrs -> Par arch (FutureArraysR arch arrs)
+  copyToHostAsync repr arrs =
+    runArraysAsync repr arrs $ \arr ->
       let n = size (shape arr)
       in  runArrayAsync arr $ \m ad ->
             copyToHostR (n*m) ad
@@ -139,9 +141,9 @@ class Async arch => Remote arch where
   -- between the two remote devices).
   --
   {-# INLINE copyToPeerAsync #-}
-  copyToPeerAsync :: Arrays arrs => arch -> arrs -> Par arch (FutureR arch arrs)
-  copyToPeerAsync peer arrs =
-    runArraysAsync arrs $ \arr ->
+  copyToPeerAsync :: arch -> ArraysR arrs -> arrs -> Par arch (FutureArraysR arch arrs)
+  copyToPeerAsync peer repr arrs =
+    runArraysAsync repr arrs $ \arr ->
       let n = size (shape arr)
       in  runArrayAsync arr $ \m ad ->
             copyToPeerR peer (n*m) ad
@@ -180,7 +182,7 @@ newRemoteAsync
     -> (sh -> e)
     -> Par arch (FutureR arch (Array sh e))
 newRemoteAsync sh f =
-  useRemoteAsync $! fromFunction sh f
+  useRemoteAsync ArraysRarray $! fromFunction sh f
 
 
 -- | Upload an immutable array from the host to the remote device. This is
@@ -189,36 +191,36 @@ newRemoteAsync sh f =
 -- possible.
 --
 {-# INLINE useRemote #-}
-useRemote :: (Remote arch, Arrays a) => a -> Par arch a
-useRemote arrs =
-  get =<< useRemoteAsync arrs
+useRemote :: Remote arch => ArraysR a -> a -> Par arch a
+useRemote repr arrs =
+  getArrays repr =<< useRemoteAsync repr arrs
 
 -- | Uploading existing arrays from the host to the remote device. This is
 -- synchronous with respect to the calling thread, but the individual array
 -- payloads may themselves be transferred concurrently.
 --
 {-# INLINE copyToRemote #-}
-copyToRemote :: (Remote arch, Arrays a) => a -> Par arch a
-copyToRemote arrs =
-  get =<< copyToRemoteAsync arrs
+copyToRemote :: Remote arch => ArraysR a -> a -> Par arch a
+copyToRemote repr arrs =
+  getArrays repr =<< copyToRemoteAsync repr arrs
 
 -- | Copy an array from the remote device to the host. This is synchronous with
 -- respect to the calling thread, but the individual array payloads may
 -- themselves be transferred concurrently.
 --
 {-# INLINE copyToHost #-}
-copyToHost :: (Remote arch, Arrays a) => a -> Par arch a
-copyToHost arrs =
-  block =<< copyToHostAsync arrs
+copyToHost :: Remote arch => ArraysR a -> a -> Par arch a
+copyToHost repr arrs =
+  blockArrays repr =<< copyToHostAsync repr arrs
 
 -- | Copy arrays between two remote instances of the same type. This may be more
 -- efficient than copying to the host and then to the second remote instance
 -- (e.g. DMA between CUDA devices).
 --
 {-# INLINE copyToPeer #-}
-copyToPeer :: (Remote arch, Arrays a) => arch -> a -> Par arch a
-copyToPeer peer arrs = do
-  get =<< copyToPeerAsync peer arrs
+copyToPeer :: Remote arch => arch -> ArraysR a -> a -> Par arch a
+copyToPeer peer repr arrs =
+  getArrays repr =<< copyToPeerAsync peer repr arrs
 
 -- | Read a single element from the remote array at the given row-major index.
 -- This is synchronous with respect to both the host and remote device.
@@ -316,11 +318,12 @@ runIndexArrayAsync worker (Array _ adata) i = (toElt . flip unsafeIndexArrayData
 --
 {-# INLINE runArrays #-}
 runArrays
-    :: forall m arrs. (Monad m, Arrays arrs)
-    => arrs
+    :: forall m arrs. Monad m
+    => ArraysR arrs
+    -> arrs
     -> (forall sh e. (Shape sh, Elt e) => Array sh e -> m (Array sh e))
     -> m arrs
-runArrays arrs worker = toArr `liftM` runR (arrays @arrs) (fromArr arrs)
+runArrays repr arrs worker = runR repr arrs
   where
     runR :: ArraysR a -> a -> m a
     runR ArraysRunit             ()             = return ()
@@ -329,16 +332,17 @@ runArrays arrs worker = toArr `liftM` runR (arrays @arrs) (fromArr arrs)
 
 {-# INLINE runArraysAsync #-}
 runArraysAsync
-    :: forall arch arrs. (Async arch, Arrays arrs)
-    => arrs
+    :: forall arch arrs. Async arch
+    => ArraysR arrs
+    -> arrs
     -> (forall sh e. (Shape sh, Elt e) => Array sh e -> Par arch (FutureR arch (Array sh e)))
-    -> Par arch (FutureR arch arrs)
-runArraysAsync arrs worker = toArr `liftF` runR (arrays @arrs) (fromArr arrs)
+    -> Par arch (FutureArraysR arch arrs)
+runArraysAsync repr arrs worker = runR repr arrs
   where
-    runR :: ArraysR a -> a -> Par arch (FutureR arch a)
-    runR ArraysRunit ()                         = newFull ()
+    runR :: ArraysR a -> a -> Par arch (FutureArraysR arch a)
+    runR ArraysRunit ()                         = return ()
     runR ArraysRarray arr                       = worker arr
-    runR (ArraysRpair aeR2 aeR1) (arrs2, arrs1) = liftF2 (,) (runR aeR2 arrs2) (runR aeR1 arrs1)
+    runR (ArraysRpair aeR2 aeR1) (arrs2, arrs1) = (,) <$> runR aeR2 arrs2 <*> runR aeR1 arrs1
 
 
 -- | Generalised function to traverse the ArrayData structure with one

--- a/accelerate-llvm/src/Data/Array/Accelerate/LLVM/CodeGen.hs
+++ b/accelerate-llvm/src/Data/Array/Accelerate/LLVM/CodeGen.hs
@@ -89,8 +89,8 @@ llvmOfPreOpenAcc uid pacc aenv = evalCodeGen $
     Apply{}                 -> unexpectedError
     Acond{}                 -> unexpectedError
     Awhile{}                -> unexpectedError
-    Atuple{}                -> unexpectedError
-    Aprj{}                  -> unexpectedError
+    Apair{}                 -> unexpectedError
+    Anil                    -> unexpectedError
     Use{}                   -> unexpectedError
     Unit{}                  -> unexpectedError
     Aforeign{}              -> unexpectedError

--- a/accelerate-llvm/src/Data/Array/Accelerate/LLVM/CodeGen/Environment.hs
+++ b/accelerate-llvm/src/Data/Array/Accelerate/LLVM/CodeGen/Environment.hs
@@ -20,7 +20,7 @@ import Data.String
 import Text.Printf
 import qualified Data.IntMap                                    as IM
 
-import Data.Array.Accelerate.AST                                ( Idx(..), idxToInt )
+import Data.Array.Accelerate.AST                                ( Idx(..), idxToInt, ArrayVar(..) )
 import Data.Array.Accelerate.Error                              ( internalError )
 import Data.Array.Accelerate.Array.Sugar                        ( Array, Shape, Elt )
 
@@ -88,6 +88,6 @@ makeGamma = snd . IM.mapAccum (\n ix -> (n+1, toAval n ix)) 0
 
 -- | A free variable
 --
-freevar :: (Shape sh, Elt e) => Idx aenv (Array sh e) -> IntMap (Idx' aenv)
-freevar ix = IM.singleton (idxToInt ix) (Idx' ix)
+freevar :: ArrayVar aenv a -> IntMap (Idx' aenv)
+freevar (ArrayVar ix) = IM.singleton (idxToInt ix) (Idx' ix)
 

--- a/accelerate-llvm/src/Data/Array/Accelerate/LLVM/CodeGen/Exp.hs
+++ b/accelerate-llvm/src/Data/Array/Accelerate/LLVM/CodeGen/Exp.hs
@@ -87,8 +87,8 @@ llvmOfOpenExp
     -> IROpenExp arch env aenv _t
 llvmOfOpenExp top env aenv = cvtE top
   where
-    cvtM :: DelayedOpenAcc aenv (Array sh e) -> IRManifest arch aenv (Array sh e)
-    cvtM (Manifest (Avar ix)) = IRManifest ix
+    cvtM :: DelayedOpenAcc aenv (Array sh e) -> ArrayVar aenv (Array sh e)
+    cvtM (Manifest (Avar ix)) = ix
     cvtM _                    = $internalError "llvmOfOpenExp" "expected manifest array variable"
 
     cvtF1 :: DelayedOpenFun env aenv (a -> b) -> IROpenFun1 arch env aenv (a -> b)
@@ -244,14 +244,14 @@ llvmOfOpenExp top env aenv = cvtE top
               = $internalError "cvtT/vec" "impossible evaluation"
 
 
-    linearIndex :: (Shape sh, Elt e) => IRManifest arch aenv (Array sh e) -> IR Int -> IROpenExp arch env aenv e
-    linearIndex (IRManifest v) = linearIndexArray (irArray (aprj v aenv))
+    linearIndex :: (Shape sh, Elt e) => ArrayVar aenv (Array sh e) -> IR Int -> IROpenExp arch env aenv e
+    linearIndex (ArrayVar v) = linearIndexArray (irArray (aprj v aenv))
 
-    index :: (Shape sh, Elt e) => IRManifest arch aenv (Array sh e) -> IR sh -> IROpenExp arch env aenv e
-    index (IRManifest v) = indexArray (irArray (aprj v aenv))
+    index :: (Shape sh, Elt e) => ArrayVar aenv (Array sh e) -> IR sh -> IROpenExp arch env aenv e
+    index (ArrayVar v) = indexArray (irArray (aprj v aenv))
 
-    shape :: (Shape sh, Elt e) => IRManifest arch aenv (Array sh e) -> IR sh
-    shape (IRManifest v) = irArrayShape (irArray (aprj v aenv))
+    shape :: (Shape sh, Elt e) => ArrayVar aenv (Array sh e) -> IR sh
+    shape (ArrayVar v) = irArrayShape (irArray (aprj v aenv))
 
     intersect :: forall sh. Shape sh => IR sh -> IR sh -> IROpenExp arch env aenv sh
     intersect (IR extent1) (IR extent2) = IR <$> go (eltType @sh) extent1 extent2

--- a/accelerate-llvm/src/Data/Array/Accelerate/LLVM/CodeGen/Skeleton.hs
+++ b/accelerate-llvm/src/Data/Array/Accelerate/LLVM/CodeGen/Skeleton.hs
@@ -109,7 +109,7 @@ class Skeleton arch where
                 -> IRFun2     arch aenv (e -> e -> e)
                 -> IRExp      arch aenv e
                 -> MIRDelayed arch aenv (Array (sh:.Int) e)
-                -> CodeGen    arch      (IROpenAcc arch aenv (Array (sh:.Int) e, Array sh e))
+                -> CodeGen    arch      (IROpenAcc arch aenv (((), Array (sh:.Int) e), Array sh e))
 
   scanl1        :: (Shape sh, Elt e)
                 => UID
@@ -132,7 +132,7 @@ class Skeleton arch where
                 -> IRFun2     arch aenv (e -> e -> e)
                 -> IRExp      arch aenv e
                 -> MIRDelayed arch aenv (Array (sh:.Int) e)
-                -> CodeGen    arch      (IROpenAcc arch aenv (Array (sh:.Int) e, Array sh e))
+                -> CodeGen    arch      (IROpenAcc arch aenv (((), Array (sh:.Int) e), Array sh e))
 
   scanr1        :: (Shape sh, Elt e)
                 => UID

--- a/accelerate-llvm/src/Data/Array/Accelerate/LLVM/CodeGen/Sugar.hs
+++ b/accelerate-llvm/src/Data/Array/Accelerate/LLVM/CodeGen/Sugar.hs
@@ -19,7 +19,6 @@ module Data.Array.Accelerate.LLVM.CodeGen.Sugar (
   IROpenExp, IROpenFun1(..), IROpenFun2(..),
   IROpenAcc(..),
   IRDelayed(..), MIRDelayed,
-  IRManifest(..),
 
   IRArray(..),
 
@@ -28,7 +27,6 @@ module Data.Array.Accelerate.LLVM.CodeGen.Sugar (
 import LLVM.AST.Type.AddrSpace
 import LLVM.AST.Type.Instruction.Volatile
 
-import Data.Array.Accelerate.AST
 import Data.Array.Accelerate.Array.Sugar
 
 import Data.Array.Accelerate.LLVM.CodeGen.IR
@@ -73,9 +71,6 @@ data IRDelayed arch aenv a where
                , delayedLinearIndex :: IRFun1 arch aenv (Int -> e)
                }
             -> IRDelayed arch aenv (Array sh e)
-
-data IRManifest arch aenv a where
-  IRManifest :: Arrays arrs => Idx aenv arrs -> IRManifest arch aenv arrs
 
 data IRArray a where
   IRArray :: { irArrayShape       :: IR sh        -- Array extent

--- a/accelerate-llvm/src/Data/Array/Accelerate/LLVM/Embed.hs
+++ b/accelerate-llvm/src/Data/Array/Accelerate/LLVM/Embed.hs
@@ -22,6 +22,8 @@ module Data.Array.Accelerate.LLVM.Embed (
   embedAfun, embedOpenAfun,
   embedOpenAcc,
 
+  HasTypeable(..), arraysTypeable, lhsTypeable
+
 ) where
 
 import LLVM.AST.Type.Name

--- a/accelerate-llvm/src/Data/Array/Accelerate/LLVM/Execute.hs
+++ b/accelerate-llvm/src/Data/Array/Accelerate/LLVM/Execute.hs
@@ -367,7 +367,7 @@ executeOpenAcc !topAcc !aenv = travA topAcc
           r2 <- new
           fork $ do
             x' <- x
-            (a :: a, b :: b) <- get x'
+            (a, b) <- get x'
             put r1 a
             put r2 b
           return (((), r1), r2)

--- a/accelerate-llvm/src/Data/Array/Accelerate/LLVM/Execute.hs
+++ b/accelerate-llvm/src/Data/Array/Accelerate/LLVM/Execute.hs
@@ -184,8 +184,8 @@ class Remote arch => Execute arch where
                 -> Delayed (Array sh b)
                 -> Par arch (FutureR arch (Array sh c))
 
-  aforeign      :: (Arrays as, Arrays bs)
-                => String
+  aforeign      :: String
+                -> ArraysR bs
                 -> (as -> Par arch (FutureR arch bs))
                 -> as
                 -> Par arch (FutureR arch bs)
@@ -214,7 +214,7 @@ data Delayed a where
 executeAcc
     :: Execute arch
     => ExecAcc arch a
-    -> Par arch (FutureR arch a)
+    -> Par arch (FutureArraysR arch a)
 executeAcc !acc =
   executeOpenAcc acc Empty
 
@@ -236,8 +236,8 @@ class ExecuteAfun arch f where
 instance (Remote arch, ExecuteAfun arch b) => ExecuteAfun arch (a -> b) where
   type ExecAfunR arch (a -> b) = a -> ExecAfunR arch b
   {-# INLINEABLE executeOpenAfun #-}
-  executeOpenAfun Abody{}  _ _    = $internalError "executeOpenAfun" "malformed array function"
-  executeOpenAfun (Alam f) k arrs =
+  executeOpenAfun Abody{}      _ _    = $internalError "executeOpenAfun" "malformed array function"
+  executeOpenAfun (Alam lhs f) k arrs =
     let k' = do aenv <- k
                 a    <- useRemoteAsync arrs
                 return (aenv `Apush` a)
@@ -293,27 +293,30 @@ executeOpenAcc
     :: forall arch aenv arrs. Execute arch
     => ExecOpenAcc arch aenv arrs
     -> ValR arch aenv
-    -> Par arch (FutureR arch arrs)
+    -> Par arch (FutureArraysR arch arrs)
 executeOpenAcc !topAcc !aenv = travA topAcc
   where
-    travA :: ExecOpenAcc arch aenv a -> Par arch (FutureR arch a)
+    travA :: ExecOpenAcc arch aenv a -> Par arch (FutureArraysR arch a)
     travA (EvalAcc pacc) =
       case pacc of
-        Use arrs            -> spawn $ useRemoteAsync (toArr arrs)
+        Use arrs            -> spawn $ useRemoteAsync ArraysRarray arrs
         Unit x              -> unit x
-        Avar ix             -> return $ prj ix aenv
-        Alet bnd body       -> alet bnd body
-        Atuple tup          -> atuple tup
+        Avar (ArrayVar ix)  -> return $ prj ix aenv
+        Alet lhs bnd body   -> alet lhs bnd body
+        Apair a1 a2         -> liftM2 (,) (travA a1) (travA a2)
+        Anil                -> return ()
         Alloc sh            -> allocate sh
         Apply f a           -> travAF f =<< spawn (travA a)
-        Aprj ix tup         -> liftF1 (evalPrj ix . fromAtuple) (travA tup)
         Acond p t e         -> acond t e =<< travE p
         Awhile p f a        -> awhile p f =<< spawn (travA a)
-        Reshape sh ix       -> liftF2 reshape (travE sh) (return $ prj ix aenv)
-        Unzip tix ix        -> liftF1 (unzip tix) (return $ prj ix aenv)
-        Aforeign str asm a  -> do
+        Reshape sh (ArrayVar ix)
+                            -> liftF2 reshape (travE sh) (return $ prj ix aenv)
+        Unzip tix (ArrayVar ix)
+                            -> liftF1 (unzip tix) (return $ prj ix aenv)
+        Aforeign str r asm a -> do
           x <- travA a
-          spawn $ aforeign str asm =<< get x
+          y <- spawn $ aforeign str r asm =<< getArrays (arraysRepr a) x
+          split r y
 
     travA (ExecAcc !gamma !kernel pacc) =
       case pacc of
@@ -332,8 +335,10 @@ executeOpenAcc !topAcc !aenv = travA topAcc
         Scanr a             -> exec1 scanr    (travD a)
         Scanl1 a            -> exec1 scanl1   (travD a)
         Scanr1 a            -> exec1 scanr1   (travD a)
-        Scanl' a            -> exec1 scanl'   (travD a)
-        Scanr' a            -> exec1 scanr'   (travD a)
+        Scanl' a            -> splitPair
+                             $ exec1 scanl'   (travD a)
+        Scanr' a            -> splitPair
+                             $ exec1 scanr'   (travD a)
         Permute d a         -> exec2 (permute_ d) (travA d) (travD a)
         Stencil1 h a        -> exec1 (stencil1 h) (travD a)
         Stencil2 h a b      -> exec2 (stencil2 h) (travD a) (travD b)
@@ -355,9 +360,21 @@ executeOpenAcc !topAcc !aenv = travA topAcc
           y' <- y
           spawn $ id =<< liftM2 (f kernel gamma aenv) (get x') (get y')
 
-    travAF :: ExecOpenAfun arch aenv (a -> b) -> FutureR arch a -> Par arch (FutureR arch b)
-    travAF (Alam (Abody f)) a = executeOpenAcc f (aenv `Push` a)
-    travAF _                _ = error "boop!"
+        splitPair :: forall a b. Par arch (FutureR arch (a, b))
+              -> Par arch (((), FutureR arch a), FutureR arch b)
+        splitPair x = do
+          r1 <- new
+          r2 <- new
+          fork $ do
+            x' <- x
+            (a :: a, b :: b) <- get x'
+            put r1 a
+            put r2 b
+          return (((), r1), r2)
+
+    travAF :: ExecOpenAfun arch aenv (a -> b) -> FutureArraysR arch a -> Par arch (FutureArraysR arch b)
+    travAF (Alam lhs (Abody f)) a = executeOpenAcc f $ aenv `push` (lhs, a)
+    travAF _                    _ = error "boop!"
 
     travE :: ExecExp arch aenv t -> Par arch (FutureR arch t)
     travE exp = executeExp exp aenv
@@ -366,29 +383,16 @@ executeOpenAcc !topAcc !aenv = travA topAcc
     travD (AST.Delayed sh) = liftF1 Delayed  (travE sh)
     travD (AST.Manifest a) = liftF1 Manifest (travA a)
 
-    travT :: Atuple (ExecOpenAcc arch aenv) t -> Par arch (FutureR arch t)
-    travT NilAtup        = newFull ()
-    travT (SnocAtup t a) = liftF2 (,) (travT t) (travA a)
-
     unit :: Elt t => ExecExp arch aenv t -> Par arch (FutureR arch (Scalar t))
     unit x = do
       x'   <- travE x
       spawn $ newRemoteAsync Z . const =<< get x'
 
-    atuple :: (Arrays t, IsAtuple t)
-           => Atuple (ExecOpenAcc arch aenv) (TupleRepr t)
-           -> Par arch (FutureR arch t)
-    atuple tup = do
-      r    <- new
-      tup' <- travT tup
-      fork $ put r . toAtuple =<< get tup'
-      return r
-
     -- Let bindings
-    alet :: ExecOpenAcc arch aenv a -> ExecOpenAcc arch (aenv, a) b -> Par arch (FutureR arch b)
-    alet bnd body = do
+    alet :: LeftHandSide a aenv aenv' -> ExecOpenAcc arch aenv a -> ExecOpenAcc arch aenv' b -> Par arch (FutureArraysR arch b)
+    alet lhs bnd body = do
       bnd'  <- spawn $ executeOpenAcc bnd aenv
-      body' <- spawn $ executeOpenAcc body (aenv `Push` bnd')
+      body' <- spawn $ executeOpenAcc body $ aenv `push` (lhs, bnd')
       return body'
 
     -- Allocate an array on the remote device
@@ -402,7 +406,7 @@ executeOpenAcc !topAcc !aenv = travA topAcc
       return r
 
     -- Array level conditionals
-    acond :: ExecOpenAcc arch aenv a -> ExecOpenAcc arch aenv a -> FutureR arch Bool -> Par arch (FutureR arch a)
+    acond :: ExecOpenAcc arch aenv a -> ExecOpenAcc arch aenv a -> FutureR arch Bool -> Par arch (FutureArraysR arch a)
     acond yes no p =
       spawn $ do
         c <- block p
@@ -412,8 +416,8 @@ executeOpenAcc !topAcc !aenv = travA topAcc
     -- Array loops
     awhile :: ExecOpenAfun arch aenv (a -> Scalar Bool)
            -> ExecOpenAfun arch aenv (a -> a)
-           -> FutureR arch a
-           -> Par arch (FutureR arch a)
+           -> FutureArraysR arch a
+           -> Par arch (FutureArraysR arch a)
     awhile p f a = do
       r  <- get =<< travAF p a
       ok <- indexRemote r 0
@@ -543,7 +547,7 @@ executeOpenExp rootExp env aenv = travE rootExp
       NilTup      -> newFull ()
       SnocTup t e -> liftF2 (,) (travT t) (travE e)
 
-    travA :: ExecOpenAcc arch aenv a -> Par arch (FutureR arch a)
+    travA :: ExecOpenAcc arch aenv a -> Par arch (FutureArraysR arch a)
     travA acc = executeOpenAcc acc aenv
 
     foreignE :: ExecFun arch () (a -> b) -> ExecOpenExp arch env aenv a -> Par arch (FutureR arch b)
@@ -647,3 +651,13 @@ infixr 0 $$
 ($$) :: (b -> a) -> (c -> d -> b) -> c -> d -> a
 (f $$ g) x y = f (g x y)
 
+split :: Execute arch => ArraysR a -> FutureR arch a -> Par arch (FutureArraysR arch a)
+split repr x = do
+  rs <- newArrays repr
+  fork $ get x >>= fill repr rs
+  return rs
+  where
+    fill :: Execute arch => ArraysR a -> FutureArraysR arch a -> a -> Par arch ()
+    fill ArraysRunit _ _ = return ()
+    fill ArraysRarray r a = put r a
+    fill (ArraysRpair repr1 repr2) (r1, r2) (a1, a2) = fill repr1 r1 a1 >> fill repr2 r2 a2

--- a/accelerate-llvm/src/Data/Array/Accelerate/LLVM/Execute/Async.hs
+++ b/accelerate-llvm/src/Data/Array/Accelerate/LLVM/Execute/Async.hs
@@ -1,5 +1,8 @@
 {-# LANGUAGE FlexibleContexts           #-}
+{-# LANGUAGE GADTs                      #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE ScopedTypeVariables        #-}
+{-# LANGUAGE TypeApplications           #-}
 {-# LANGUAGE TypeFamilies               #-}
 {-# OPTIONS_HADDOCK hide #-}
 -- |
@@ -15,6 +18,7 @@
 module Data.Array.Accelerate.LLVM.Execute.Async
   where
 
+import Data.Array.Accelerate.Array.Sugar 
 
 class Monad (Par arch) => Async arch where
 
@@ -58,9 +62,9 @@ class Monad (Par arch) => Async arch where
   -- more efficiently than the default implementation.
   --
   {-# INLINEABLE spawn #-}
-  spawn :: Par arch (FutureR arch a) -> Par arch (FutureR arch a)
+  spawn :: Par arch a -> Par arch a
   spawn m = do
-    r <- new              -- Future (Future a)  |:
+    r <- new
     fork $ put r =<< m
     get r
 
@@ -74,3 +78,44 @@ class Monad (Par arch) => Async arch where
     put r a
     return r
 
+data FutureArraysRepr arch a repr where
+  FutureArraysReprNil       :: FutureArraysRepr arch ()            ()
+  FutureArraysReprArray     :: FutureArraysRepr arch (Array sh e) (FutureR arch (Array sh e))
+  FutureArraysReprPair      :: FutureArraysRepr arch a             a'
+                            -> FutureArraysRepr arch b             b'
+                            -> FutureArraysRepr arch (a, b)        (a', b')
+
+class FutureArrays a where
+  type FutureArraysR arch a
+  futureArraysRepr :: FutureArraysRepr arch a (FutureArraysR arch a)
+
+instance FutureArrays () where
+  type FutureArraysR arch () = ()
+  futureArraysRepr = FutureArraysReprNil
+
+instance FutureArrays (Array sh e) where
+  type FutureArraysR arch (Array sh e) = FutureR arch (Array sh e)
+  futureArraysRepr = FutureArraysReprArray
+
+instance (FutureArrays a, FutureArrays b) => FutureArrays (a, b) where
+  type FutureArraysR arch (a, b) = (FutureArraysR arch a, FutureArraysR arch b)
+  futureArraysRepr = FutureArraysReprPair (futureArraysRepr @a) (futureArraysRepr @b)
+
+getArrays :: Async arch => ArraysR a -> FutureArraysR arch a -> Par arch a
+getArrays ArraysRarray        a        = get a
+getArrays ArraysRunit         _        = return ()
+getArrays (ArraysRpair r1 r2) (a1, a2) = (,) <$> getArrays r1 a1 <*> getArrays r2 a2
+
+blockArrays :: Async arch => ArraysR a -> FutureArraysR arch a -> Par arch a
+blockArrays ArraysRarray        a        = block a
+blockArrays ArraysRunit         _        = return ()
+blockArrays (ArraysRpair r1 r2) (a1, a2) = (,) <$> blockArrays r1 a1 <*> blockArrays r2 a2
+
+-- | Create new (empty) promises for a structure of arrays, to be fulfilled
+-- at some future point. Note that the promises in the structure may all be
+-- fullfilled at different moments.
+--
+newArrays :: Async arch => ArraysR a -> Par arch (FutureArraysR arch a)
+newArrays ArraysRunit               = return ()
+newArrays ArraysRarray              = new
+newArrays (ArraysRpair repr1 repr2) = (,) <$> newArrays repr1 <*> newArrays repr2

--- a/accelerate-llvm/src/Data/Array/Accelerate/LLVM/Execute/Environment.hs
+++ b/accelerate-llvm/src/Data/Array/Accelerate/LLVM/Execute/Environment.hs
@@ -17,7 +17,7 @@ module Data.Array.Accelerate.LLVM.Execute.Environment
   where
 
 -- accelerate
-import Data.Array.Accelerate.AST                                    ( Idx(..) )
+import Data.Array.Accelerate.AST                                    ( Idx(..), LeftHandSide(..) )
 #if __GLASGOW_HASKELL__ < 800
 import Data.Array.Accelerate.Error
 #endif
@@ -34,6 +34,10 @@ data ValR arch env where
   Empty :: ValR arch ()
   Push  :: ValR arch env -> FutureR arch t -> ValR arch (env, t)
 
+push :: ValR arch env -> (LeftHandSide t env env', FutureArraysR arch t) -> ValR arch env'
+push env (LeftHandSideWildcard _, _       ) = env
+push env (LeftHandSideArray     , a       ) = env `Push` a
+push env (LeftHandSidePair l1 l2, (a1, a2)) = push env (l1, a1) `push` (l2, a2)
 
 -- Projection of a value from a valuation using a de Bruijn index.
 --

--- a/accelerate-llvm/src/Data/Array/Accelerate/LLVM/Foreign.hs
+++ b/accelerate-llvm/src/Data/Array/Accelerate/LLVM/Foreign.hs
@@ -25,9 +25,9 @@ import Data.Typeable
 -- array and scalar expressions.
 --
 class Foreign arch where
-  foreignAcc :: (A.Foreign asm, Typeable a, Typeable b)
+  foreignAcc :: (A.Foreign asm, A.Arrays a, A.Arrays b)
              => asm (a -> b)
-             -> Maybe (a -> Par arch (FutureR arch b))
+             -> Maybe (ArrRepr a -> Par arch (FutureR arch (ArrRepr b)))
   foreignAcc _ = Nothing
 
   foreignExp :: (A.Foreign asm, Typeable x, Typeable y)

--- a/accelerate-llvm/src/Data/Array/Accelerate/LLVM/Link.hs
+++ b/accelerate-llvm/src/Data/Array/Accelerate/LLVM/Link.hs
@@ -60,9 +60,12 @@ data ExecOpenAcc arch aenv a where
             -> PreOpenAccSkeleton ExecOpenAcc arch aenv a
             -> ExecOpenAcc arch aenv a
 
-  EvalAcc   :: Arrays a
-            => PreOpenAccCommand  ExecOpenAcc arch aenv a
+  EvalAcc   :: PreOpenAccCommand  ExecOpenAcc arch aenv a
             -> ExecOpenAcc arch aenv a
+
+instance HasArraysRepr (ExecOpenAcc arch) where
+  arraysRepr (ExecAcc _ _ a) = arraysRepr a
+  arraysRepr (EvalAcc a)     = arraysRepr a
 
 -- An AST annotated with compiled and linked functions in the target address
 -- space, suitable for execution.
@@ -101,8 +104,8 @@ linkOpenAfun
     :: Link arch
     => CompiledOpenAfun arch aenv f
     -> LLVM arch (ExecOpenAfun arch aenv f)
-linkOpenAfun (Alam l)  = Alam  <$> linkOpenAfun l
-linkOpenAfun (Abody b) = Abody <$> linkOpenAcc b
+linkOpenAfun (Alam lhs l) = Alam lhs <$> linkOpenAfun l
+linkOpenAfun (Abody b)    = Abody    <$> linkOpenAcc b
 
 {-# INLINEABLE linkOpenAcc #-}
 linkOpenAcc
@@ -116,17 +119,17 @@ linkOpenAcc = travA
       case pacc of
         Unzip tix ix            -> return (Unzip tix ix)
         Avar ix                 -> return (Avar ix)
-        Use arrs                -> rnfArrs (arrays @arrs) arrs `seq` return (Use arrs)
+        Use arr                 -> rnf arr `seq` return (Use arr)
         Unit e                  -> Unit         <$> travE e
         Alloc sh                -> Alloc        <$> travE sh
-        Alet a b                -> Alet         <$> travA a  <*> travA b
+        Alet lhs a b            -> Alet lhs     <$> travA a  <*> travA b
         Apply f a               -> Apply        <$> travAF f <*> travA a
         Awhile p f a            -> Awhile       <$> travAF p <*> travAF f <*> travA a
         Acond p t e             -> Acond        <$> travE p  <*> travA t  <*> travA e
-        Atuple tup              -> Atuple       <$> travAtup tup
-        Aprj ix tup             -> Aprj ix      <$> travA tup
+        Apair a1 a2             -> Apair        <$> travA a1 <*> travA a2
+        Anil                    -> return Anil
         Reshape s ix            -> Reshape      <$> travE s <*> pure ix
-        Aforeign s f a          -> Aforeign s f <$> travA a
+        Aforeign s r f a        -> Aforeign s r f <$> travA a
 
     travA (BuildAcc aenv obj pacc) = ExecAcc aenv <$> linkForTarget obj <*>
       case pacc of
@@ -156,11 +159,6 @@ linkOpenAcc = travA
           -> LLVM arch (DelayedOpenAcc ExecOpenAcc arch aenv a)
     travD (Manifest a) = Manifest <$> travA a
     travD (Delayed sh) = Delayed  <$> travE sh
-
-    travAtup :: Atuple (CompiledOpenAcc arch aenv) a
-             -> LLVM arch (Atuple (ExecOpenAcc arch aenv) a)
-    travAtup NilAtup        = return NilAtup
-    travAtup (SnocAtup t a) = SnocAtup <$> travAtup t <*> travA a
 
     travF :: CompiledOpenFun arch env aenv t
           -> LLVM arch (ExecOpenFun arch env aenv t)
@@ -204,9 +202,4 @@ linkOpenAcc = travA
           -> LLVM arch (Tuple (ExecOpenExp arch env aenv) t)
     travT NilTup        = return NilTup
     travT (SnocTup t e) = SnocTup <$> travT t <*> travE e
-
-    rnfArrs :: ArraysR a -> a -> ()
-    rnfArrs (ArraysRpair ar1 ar2) (a1, a2) = rnfArrs ar1 a1 `seq` rnfArrs ar2 a2
-    rnfArrs ArraysRarray arr               = rnf arr
-    rnfArrs ArraysRunit ()                 = ()
 

--- a/stack-8.0.yaml
+++ b/stack-8.0.yaml
@@ -10,7 +10,7 @@ packages:
 
 extra-deps:
 - github: tmcdonell/accelerate
-  commit: 8c64c6567619056da2eeca046669eab5f5ae79b6
+  commit: 1010d97f8cc8cbecff28200cf6e176455769c644
 
 - cuda-0.10.0.0
 - half-0.3

--- a/stack-8.0.yaml
+++ b/stack-8.0.yaml
@@ -10,7 +10,7 @@ packages:
 
 extra-deps:
 - github: ivogabe/accelerate
-  commit: 52ee6eadc0f4f75de8c6e16cf2e611a8f94fd8f1
+  commit: db2567360d3623e23e341386e49f5a944ce3af5f
 
 - cuda-0.10.0.0
 - half-0.3

--- a/stack-8.2.yaml
+++ b/stack-8.2.yaml
@@ -10,7 +10,7 @@ packages:
 
 extra-deps:
 - github: tmcdonell/accelerate
-  commit: 8c64c6567619056da2eeca046669eab5f5ae79b6
+  commit: 1010d97f8cc8cbecff28200cf6e176455769c644
 
 - cuda-0.10.0.0
 - half-0.3

--- a/stack-8.2.yaml
+++ b/stack-8.2.yaml
@@ -10,7 +10,7 @@ packages:
 
 extra-deps:
 - github: ivogabe/accelerate
-  commit: 52ee6eadc0f4f75de8c6e16cf2e611a8f94fd8f1
+  commit: db2567360d3623e23e341386e49f5a944ce3af5f
 
 - cuda-0.10.0.0
 - half-0.3

--- a/stack-8.4.yaml
+++ b/stack-8.4.yaml
@@ -10,7 +10,7 @@ packages:
 
 extra-deps:
 - github: ivogabe/accelerate
-  commit: 52ee6eadc0f4f75de8c6e16cf2e611a8f94fd8f1
+  commit: db2567360d3623e23e341386e49f5a944ce3af5f
 
 - cuda-0.10.0.0
 - nvvm-0.9.0.0

--- a/stack-8.4.yaml
+++ b/stack-8.4.yaml
@@ -10,7 +10,7 @@ packages:
 
 extra-deps:
 - github: tmcdonell/accelerate
-  commit: 8c64c6567619056da2eeca046669eab5f5ae79b6
+  commit: 1010d97f8cc8cbecff28200cf6e176455769c644
 
 - cuda-0.10.0.0
 - nvvm-0.9.0.0

--- a/stack-8.6.yaml
+++ b/stack-8.6.yaml
@@ -1,7 +1,7 @@
 # For more information, see: https://github.com/commercialhaskell/stack/blob/release/doc/yaml_configuration.md
 # vim: nospell
 
-resolver: lts-13.25
+resolver: lts-14.3
 
 packages:
 - accelerate-llvm
@@ -11,12 +11,6 @@ packages:
 extra-deps:
 - github: tmcdonell/accelerate
   commit: 1010d97f8cc8cbecff28200cf6e176455769c644
-
-- cuda-0.10.1.0
-- hedgehog-1.0
-- llvm-hs-8.0.0
-- llvm-hs-pure-8.0.0
-- tasty-hedgehog-1.0.0.1
 
 # Override default flag values for local packages and extra-deps
 # flags: {}

--- a/stack-8.6.yaml
+++ b/stack-8.6.yaml
@@ -10,7 +10,7 @@ packages:
 
 extra-deps:
 - github: ivogabe/accelerate
-  commit: 52ee6eadc0f4f75de8c6e16cf2e611a8f94fd8f1
+  commit: db2567360d3623e23e341386e49f5a944ce3af5f
 
 # Override default flag values for local packages and extra-deps
 # flags: {}

--- a/stack-8.6.yaml
+++ b/stack-8.6.yaml
@@ -10,7 +10,7 @@ packages:
 
 extra-deps:
 - github: tmcdonell/accelerate
-  commit: 8c64c6567619056da2eeca046669eab5f5ae79b6
+  commit: 1010d97f8cc8cbecff28200cf6e176455769c644
 
 - cuda-0.10.1.0
 - hedgehog-1.0


### PR DESCRIPTION
For a general description, see AccelerateHS/accelerate#449. This is the related change in accelerate-llvm.

- The type argument of ...Acc regards representation types.
- Tuples of arrays are now embedded in the AST using pairs and nils
- The Arrays type class is not used in the ASTs, instead we add the
  data type ArrRepr which acts as evidence to some constructors
- Projections are removed
- A let binding may declare multiple variables. If the right hand side is a tuple,
  it is destructured into multiple variables,
  such that each variable is an array.
- In the execution, we now use tuples of futures instead of a future of
  tuples. This allows that one part of an Apair may be evaluated before
  the other and thus allows more operations to be executed in parallel

Status
- [x] accelerate-llvm
- [x] accelerate-llvm-native
- [x] accelerate-llvm-ptx
