### PR TITLE
Include AST node hash in -ddump-exec output

### DIFF
--- a/accelerate-llvm-native/src/Data/Array/Accelerate/LLVM/Native/Embed.hs
+++ b/accelerate-llvm-native/src/Data/Array/Accelerate/LLVM/Native/Embed.hs
@@ -62,7 +62,7 @@ instance Embed Native where
 embed :: Native -> ObjectR Native -> Q (TExp (ExecutableR Native))
 embed target (ObjectR uid nms !_) = do
   objFile <- getObjectFile
-  funtab  <- forM nms $ \fn -> return [|| ( $$(liftSBS (BS.take (BS.length fn - 65) fn)), $$(makeFFI fn objFile) ) ||]
+  funtab  <- forM nms $ \fn -> return [|| ( $$(liftSBS (BS.take (BS.length fn - 0) fn)), $$(makeFFI fn objFile) ) ||]
   --
   [|| NativeR (unsafePerformIO $ newLifetime (FunctionTable $$(listE funtab))) ||]
   where

--- a/accelerate-llvm-native/src/Data/Array/Accelerate/LLVM/Native/Execute.hs
+++ b/accelerate-llvm-native/src/Data/Array/Accelerate/LLVM/Native/Execute.hs
@@ -62,6 +62,8 @@ import Data.Sequence                                                ( Seq )
 import Data.Foldable                                                ( asum )
 import System.CPUTime                                               ( getCPUTime )
 import Text.Printf                                                  ( printf )
+import qualified Data.ByteString.Char8                              as B8
+import qualified Data.ByteString.Short                              as BS
 import qualified Data.ByteString.Short.Char8                        as S8
 import qualified Data.Sequence                                      as Seq
 import qualified Data.DList                                         as DL
@@ -788,7 +790,8 @@ aforeignOp name _ _ asm arr = do
 
 lookupFunction :: ShortByteString -> Lifetime FunctionTable -> Maybe Function
 lookupFunction name nativeExecutable = do
-  find (\(n,_) -> n == name) (functionTable (unsafeGetValue nativeExecutable))
+  let shorten n = BS.toShort (B8.take (BS.length n - 65) (BS.fromShort n))
+  find (\(n,_) -> shorten n == name) (functionTable (unsafeGetValue nativeExecutable))
 
 andThen :: (Maybe a -> t) -> a -> t
 andThen f g = f (Just g)

--- a/accelerate-llvm-native/src/Data/Array/Accelerate/LLVM/Native/Link/ELF.chs
+++ b/accelerate-llvm-native/src/Data/Array/Accelerate/LLVM/Native/Link/ELF.chs
@@ -176,7 +176,7 @@ loadSegment obj strtab secs symtab relocs = do
               let funtab              = FunctionTable $ V.toList (V.map resolve (V.filter extern symtab))
                   extern Symbol{..}   = sym_binding == Global && sym_type == Func
                   resolve Symbol{..}  =
-                    let name  = BS.toShort (B8.take (B8.length sym_name - 65) sym_name)
+                    let name  = BS.toShort (B8.take (B8.length sym_name - 0) sym_name)
                         addr  = castPtrToFunPtr (seg_p `plusPtr` (fromIntegral sym_value + offsets V.! sym_section))
                     in
                     (name, addr)

--- a/accelerate-llvm-native/src/Data/Array/Accelerate/LLVM/Native/Link/MachO.chs
+++ b/accelerate-llvm-native/src/Data/Array/Accelerate/LLVM/Native/Link/MachO.chs
@@ -101,7 +101,7 @@ loadSegments obj symtab lcs = do
   let extern Symbol{..}   = sym_extern && sym_segment > 0
       resolve Symbol{..}  =
         let Segment _ fp  = segs V.! (fromIntegral (sym_segment-1))
-            name          = BS.toShort (B8.take (B8.length sym_name - 65) sym_name)
+            name          = BS.toShort (B8.take (B8.length sym_name - 0) sym_name)
             addr          = castPtrToFunPtr (unsafeForeignPtrToPtr fp `plusPtr` fromIntegral sym_value)
         in
         (name, addr)

--- a/accelerate-llvm-ptx/src/Data/Array/Accelerate/LLVM/PTX/CodeGen.hs
+++ b/accelerate-llvm-ptx/src/Data/Array/Accelerate/LLVM/PTX/CodeGen.hs
@@ -32,14 +32,14 @@ import Data.Array.Accelerate.LLVM.PTX.Target
 
 
 instance Skeleton PTX where
-  map _       = mkMap
-  generate _  = mkGenerate
-  transform _ = mkTransform
-  fold _      = mkFold
-  foldSeg _   = mkFoldSeg
-  scan _      = mkScan
-  scan' _     = mkScan'
-  permute _   = mkPermute
-  stencil1 _  = mkStencil1
-  stencil2 _  = mkStencil2
+  map         = mkMap
+  generate    = mkGenerate
+  transform   = mkTransform
+  fold        = mkFold
+  foldSeg     = mkFoldSeg
+  scan        = mkScan
+  scan'       = mkScan'
+  permute     = mkPermute
+  stencil1    = mkStencil1
+  stencil2    = mkStencil2
 

--- a/accelerate-llvm-ptx/src/Data/Array/Accelerate/LLVM/PTX/CodeGen/Base.hs
+++ b/accelerate-llvm-ptx/src/Data/Array/Accelerate/LLVM/PTX/CodeGen/Base.hs
@@ -92,10 +92,9 @@ import Prelude                                                      as P
 #if MIN_VERSION_llvm_hs(10,0,0)
 import qualified LLVM.AST.Type.Instruction.RMW                      as RMW
 import LLVM.AST.Type.Instruction.Atomic
-#elif !MIN_VERSION_llvm_hs(9,0,0)
+#endif
 import Data.String
 import Text.Printf
-#endif
 
 
 -- Thread identifiers
@@ -481,8 +480,8 @@ makeOpenAccWith
     -> [LLVM.Parameter]
     -> CodeGen PTX ()
     -> CodeGen PTX (IROpenAcc PTX aenv a)
-makeOpenAccWith config _uid name param kernel = do
-  body  <- makeKernel config name param kernel
+makeOpenAccWith config uid name param kernel = do
+  body  <- makeKernel config (name <> fromString (printf "_%s" (show uid))) param kernel
   return $ IROpenAcc [body]
 
 -- | Create a complete kernel function by running the code generation process

--- a/accelerate-llvm-ptx/src/Data/Array/Accelerate/LLVM/PTX/CodeGen/Base.hs
+++ b/accelerate-llvm-ptx/src/Data/Array/Accelerate/LLVM/PTX/CodeGen/Base.hs
@@ -48,6 +48,7 @@ module Data.Array.Accelerate.LLVM.PTX.CodeGen.Base (
 ) where
 
 import Data.Array.Accelerate.Error
+import Data.Array.Accelerate.LLVM.Compile.Cache                     ( UID )
 import Data.Array.Accelerate.LLVM.CodeGen.Arithmetic                as A
 import Data.Array.Accelerate.LLVM.CodeGen.Base
 import Data.Array.Accelerate.LLVM.CodeGen.Constant
@@ -462,23 +463,25 @@ IROpenAcc k1 +++ IROpenAcc k2 = IROpenAcc (k1 ++ k2)
 -- | Create a single kernel program with the default launch configuration.
 --
 makeOpenAcc
-    :: Label
+    :: UID
+    -> Label
     -> [LLVM.Parameter]
     -> CodeGen PTX ()
     -> CodeGen PTX (IROpenAcc PTX aenv a)
-makeOpenAcc name param kernel = do
+makeOpenAcc uid name param kernel = do
   dev <- liftCodeGen $ gets ptxDeviceProperties
-  makeOpenAccWith (simpleLaunchConfig dev) name param kernel
+  makeOpenAccWith (simpleLaunchConfig dev) uid name param kernel
 
 -- | Create a single kernel program with the given launch analysis information.
 --
 makeOpenAccWith
     :: LaunchConfig
+    -> UID
     -> Label
     -> [LLVM.Parameter]
     -> CodeGen PTX ()
     -> CodeGen PTX (IROpenAcc PTX aenv a)
-makeOpenAccWith config name param kernel = do
+makeOpenAccWith config _uid name param kernel = do
   body  <- makeKernel config name param kernel
   return $ IROpenAcc [body]
 

--- a/accelerate-llvm-ptx/src/Data/Array/Accelerate/LLVM/PTX/CodeGen/Fold.hs
+++ b/accelerate-llvm-ptx/src/Data/Array/Accelerate/LLVM/PTX/CodeGen/Fold.hs
@@ -35,6 +35,7 @@ import Data.Array.Accelerate.LLVM.CodeGen.IR
 import Data.Array.Accelerate.LLVM.CodeGen.Loop                      as Loop
 import Data.Array.Accelerate.LLVM.CodeGen.Monad
 import Data.Array.Accelerate.LLVM.CodeGen.Sugar
+import Data.Array.Accelerate.LLVM.Compile.Cache                     ( UID )
 
 import Data.Array.Accelerate.LLVM.PTX.Analysis.Launch
 import Data.Array.Accelerate.LLVM.PTX.CodeGen.Base
@@ -61,19 +62,20 @@ import Prelude                                                      as P
 --
 mkFold
     :: forall aenv sh e.
-       Gamma            aenv
+       UID
+    -> Gamma            aenv
     -> ArrayR (Array sh e)
     -> IRFun2       PTX aenv (e -> e -> e)
     -> Maybe (IRExp PTX aenv e)
     -> MIRDelayed   PTX aenv (Array (sh, Int) e)
     -> CodeGen      PTX      (IROpenAcc PTX aenv (Array sh e))
-mkFold aenv repr f z acc = case z of
-  Just z' -> (+++) <$> codeFold <*> mkFoldFill aenv repr z'
+mkFold uid aenv repr f z acc = case z of
+  Just z' -> (+++) <$> codeFold <*> mkFoldFill uid aenv repr z'
   Nothing -> codeFold
   where
     codeFold = case repr of
-      ArrayR ShapeRz tp -> mkFoldAll aenv tp   f z acc
-      _                 -> mkFoldDim aenv repr f z acc
+      ArrayR ShapeRz tp -> mkFoldAll uid aenv tp   f z acc
+      _                 -> mkFoldDim uid aenv repr f z acc
 
 
 -- Reduce an array to a single element.
@@ -96,17 +98,18 @@ mkFold aenv repr f z acc = case z of
 --
 mkFoldAll
     :: forall aenv e.
-       Gamma          aenv                      -- ^ array environment
+       UID
+    -> Gamma          aenv                      -- ^ array environment
     -> TypeR e
     -> IRFun2     PTX aenv (e -> e -> e)        -- ^ combination function
     -> MIRExp     PTX aenv e                    -- ^ (optional) initial element for exclusive reductions
     -> MIRDelayed PTX aenv (Vector e)           -- ^ input data
     -> CodeGen    PTX      (IROpenAcc PTX aenv (Scalar e))
-mkFoldAll aenv tp combine mseed macc = do
+mkFoldAll uid aenv tp combine mseed macc = do
   dev <- liftCodeGen $ gets ptxDeviceProperties
-  foldr1 (+++) <$> sequence [ mkFoldAllS  dev aenv tp combine mseed macc
-                            , mkFoldAllM1 dev aenv tp combine       macc
-                            , mkFoldAllM2 dev aenv tp combine mseed
+  foldr1 (+++) <$> sequence [ mkFoldAllS  uid dev aenv tp combine mseed macc
+                            , mkFoldAllM1 uid dev aenv tp combine       macc
+                            , mkFoldAllM2 uid dev aenv tp combine mseed
                             ]
 
 
@@ -115,14 +118,15 @@ mkFoldAll aenv tp combine mseed macc = do
 --
 mkFoldAllS
     :: forall aenv e.
-       DeviceProperties                         -- ^ properties of the target GPU
+       UID
+    -> DeviceProperties                         -- ^ properties of the target GPU
     -> Gamma          aenv                      -- ^ array environment
     -> TypeR e
     -> IRFun2     PTX aenv (e -> e -> e)        -- ^ combination function
     -> MIRExp     PTX aenv e                    -- ^ (optional) initial element for exclusive reductions
     -> MIRDelayed PTX aenv (Vector e)           -- ^ input data
     -> CodeGen    PTX      (IROpenAcc PTX aenv (Scalar e))
-mkFoldAllS dev aenv tp combine mseed marr =
+mkFoldAllS uid dev aenv tp combine mseed marr =
   let
       (arrOut, paramOut)  = mutableArray (ArrayR dim0 tp) "out"
       (arrIn,  paramIn)   = delayedArray "in" marr
@@ -136,7 +140,7 @@ mkFoldAllS dev aenv tp combine mseed marr =
           per_warp  = ws + ws `P.quot` 2
           bytes     = bytesElt tp
   in
-  makeOpenAccWith config "foldAllS" (paramOut ++ paramIn ++ paramEnv) $ do
+  makeOpenAccWith config uid "foldAllS" (paramOut ++ paramIn ++ paramEnv) $ do
 
     tid     <- threadIdx
     bd      <- blockDim
@@ -173,13 +177,14 @@ mkFoldAllS dev aenv tp combine mseed marr =
 --
 mkFoldAllM1
     :: forall aenv e.
-       DeviceProperties                         -- ^ properties of the target GPU
+       UID
+    -> DeviceProperties                         -- ^ properties of the target GPU
     -> Gamma          aenv                      -- ^ array environment
     -> TypeR e
     -> IRFun2     PTX aenv (e -> e -> e)        -- ^ combination function
     -> MIRDelayed PTX aenv (Vector e)           -- ^ input data
     -> CodeGen    PTX      (IROpenAcc PTX aenv (Scalar e))
-mkFoldAllM1 dev aenv tp combine marr =
+mkFoldAllM1 uid dev aenv tp combine marr =
   let
       (arrTmp, paramTmp)  = mutableArray (ArrayR dim1 tp) "tmp"
       (arrIn,  paramIn)   = delayedArray "in" marr
@@ -194,7 +199,7 @@ mkFoldAllM1 dev aenv tp combine marr =
           per_warp  = ws + ws `P.quot` 2
           bytes     = bytesElt tp
   in
-  makeOpenAccWith config "foldAllM1" (paramTmp ++ paramIn ++ paramEnv) $ do
+  makeOpenAccWith config uid "foldAllM1" (paramTmp ++ paramIn ++ paramEnv) $ do
 
     -- Each thread block cooperatively reduces a stripe of the input and stores
     -- that value into a temporary array at a corresponding index. Since the
@@ -229,13 +234,14 @@ mkFoldAllM1 dev aenv tp combine marr =
 --
 mkFoldAllM2
     :: forall aenv e.
-       DeviceProperties
+       UID
+    -> DeviceProperties
     -> Gamma       aenv
     -> TypeR e
     -> IRFun2  PTX aenv (e -> e -> e)
     -> MIRExp  PTX aenv e
     -> CodeGen PTX      (IROpenAcc PTX aenv (Scalar e))
-mkFoldAllM2 dev aenv tp combine mseed =
+mkFoldAllM2 uid dev aenv tp combine mseed =
   let
       (arrTmp, paramTmp)  = mutableArray (ArrayR dim1 tp) "tmp"
       (arrOut, paramOut)  = mutableArray (ArrayR dim1 tp) "out"
@@ -250,7 +256,7 @@ mkFoldAllM2 dev aenv tp combine mseed =
           per_warp  = ws + ws `P.quot` 2
           bytes     = bytesElt tp
   in
-  makeOpenAccWith config "foldAllM2" (paramTmp ++ paramOut ++ paramEnv) $ do
+  makeOpenAccWith config uid "foldAllM2" (paramTmp ++ paramOut ++ paramEnv) $ do
 
     -- Threads cooperatively reduce a stripe of the input (temporary) array
     -- output from the first phase, storing the results into another temporary.
@@ -296,13 +302,14 @@ mkFoldAllM2 dev aenv tp combine mseed =
 --
 mkFoldDim
     :: forall aenv sh e.
-       Gamma aenv                                     -- ^ array environment
+       UID
+    -> Gamma aenv                                     -- ^ array environment
     -> ArrayR (Array sh e)
     -> IRFun2     PTX aenv (e -> e -> e)              -- ^ combination function
     -> MIRExp     PTX aenv e                          -- ^ (optional) seed element, if this is an exclusive reduction
     -> MIRDelayed PTX aenv (Array (sh, Int) e)        -- ^ input data
     -> CodeGen    PTX      (IROpenAcc PTX aenv (Array sh e))
-mkFoldDim aenv repr@(ArrayR shr tp) combine mseed marr = do
+mkFoldDim uid aenv repr@(ArrayR shr tp) combine mseed marr = do
   dev <- liftCodeGen $ gets ptxDeviceProperties
   --
   let
@@ -318,7 +325,7 @@ mkFoldDim aenv repr@(ArrayR shr tp) combine mseed marr = do
           per_warp  = ws + ws `P.quot` 2
           bytes     = bytesElt tp
   --
-  makeOpenAccWith config "fold" (paramOut ++ paramIn ++ paramEnv) $ do
+  makeOpenAccWith config uid "fold" (paramOut ++ paramIn ++ paramEnv) $ do
 
     -- If the innermost dimension is smaller than the number of threads in the
     -- block, those threads will never contribute to the output.
@@ -411,12 +418,13 @@ mkFoldDim aenv repr@(ArrayR shr tp) combine mseed marr = do
 -- dimensions with the initial element.
 --
 mkFoldFill
-    :: Gamma       aenv
+    :: UID
+    -> Gamma       aenv
     -> ArrayR (Array sh e)
     -> IRExp   PTX aenv e
     -> CodeGen PTX      (IROpenAcc PTX aenv (Array sh e))
-mkFoldFill aenv repr seed =
-  mkGenerate aenv repr (IRFun1 (const seed))
+mkFoldFill uid aenv repr seed =
+  mkGenerate uid aenv repr (IRFun1 (const seed))
 
 
 -- Efficient threadblock-wide reduction using the specified operator. The

--- a/accelerate-llvm-ptx/src/Data/Array/Accelerate/LLVM/PTX/CodeGen/Generate.hs
+++ b/accelerate-llvm-ptx/src/Data/Array/Accelerate/LLVM/PTX/CodeGen/Generate.hs
@@ -27,6 +27,7 @@ import Data.Array.Accelerate.LLVM.CodeGen.Environment
 import Data.Array.Accelerate.LLVM.CodeGen.Exp
 import Data.Array.Accelerate.LLVM.CodeGen.Monad
 import Data.Array.Accelerate.LLVM.CodeGen.Sugar
+import Data.Array.Accelerate.LLVM.Compile.Cache                 ( UID )
 
 import Data.Array.Accelerate.LLVM.PTX.CodeGen.Base
 import Data.Array.Accelerate.LLVM.PTX.CodeGen.Loop
@@ -37,16 +38,17 @@ import Data.Array.Accelerate.LLVM.PTX.Target                    ( PTX )
 -- processes multiple adjacent elements.
 --
 mkGenerate
-    :: Gamma aenv
+    :: UID
+    -> Gamma aenv
     -> ArrayR (Array sh e)
     -> IRFun1  PTX aenv (sh -> e)
     -> CodeGen PTX      (IROpenAcc PTX aenv (Array sh e))
-mkGenerate aenv repr@(ArrayR shr _) apply =
+mkGenerate uid aenv repr@(ArrayR shr _) apply =
   let
       (arrOut, paramOut)  = mutableArray repr "out"
       paramEnv            = envParam aenv
   in
-  makeOpenAcc "generate" (paramOut ++ paramEnv) $ do
+  makeOpenAcc uid "generate" (paramOut ++ paramEnv) $ do
 
     start <- return (liftInt 0)
     end   <- shapeSize shr (irArrayShape arrOut)

--- a/accelerate-llvm-ptx/src/Data/Array/Accelerate/LLVM/PTX/CodeGen/Map.hs
+++ b/accelerate-llvm-ptx/src/Data/Array/Accelerate/LLVM/PTX/CodeGen/Map.hs
@@ -27,6 +27,7 @@ import Data.Array.Accelerate.LLVM.CodeGen.Environment
 import Data.Array.Accelerate.LLVM.CodeGen.Exp
 import Data.Array.Accelerate.LLVM.CodeGen.Monad
 import Data.Array.Accelerate.LLVM.CodeGen.Sugar
+import Data.Array.Accelerate.LLVM.Compile.Cache                 ( UID )
 
 import Data.Array.Accelerate.LLVM.PTX.CodeGen.Base
 import Data.Array.Accelerate.LLVM.PTX.CodeGen.Loop
@@ -36,18 +37,19 @@ import Data.Array.Accelerate.LLVM.PTX.Target                    ( PTX )
 -- Apply a unary function to each element of an array. Each thread processes
 -- multiple elements, striding the array by the grid size.
 --
-mkMap :: Gamma       aenv
+mkMap :: UID
+      -> Gamma       aenv
       -> ArrayR (Array sh a)
       -> TypeR b
       -> IRFun1  PTX aenv (a -> b)
       -> CodeGen PTX      (IROpenAcc PTX aenv (Array sh b))
-mkMap aenv repr@(ArrayR shr _) tp' apply =
+mkMap uid aenv repr@(ArrayR shr _) tp' apply =
   let
       (arrOut, paramOut)  = mutableArray (ArrayR shr tp') "out"
       (arrIn,  paramIn)   = mutableArray repr             "in"
       paramEnv            = envParam aenv
   in
-  makeOpenAcc "map" (paramOut ++ paramIn ++ paramEnv) $ do
+  makeOpenAcc uid "map" (paramOut ++ paramIn ++ paramEnv) $ do
 
     start <- return (liftInt 0)
     end   <- shapeSize shr (irArrayShape arrIn)

--- a/accelerate-llvm-ptx/src/Data/Array/Accelerate/LLVM/PTX/CodeGen/Permute.hs
+++ b/accelerate-llvm-ptx/src/Data/Array/Accelerate/LLVM/PTX/CodeGen/Permute.hs
@@ -39,6 +39,7 @@ import Data.Array.Accelerate.LLVM.CodeGen.Monad
 import Data.Array.Accelerate.LLVM.CodeGen.Permute
 import Data.Array.Accelerate.LLVM.CodeGen.Ptr
 import Data.Array.Accelerate.LLVM.CodeGen.Sugar
+import Data.Array.Accelerate.LLVM.Compile.Cache                     ( UID )
 
 import Data.Array.Accelerate.LLVM.PTX.CodeGen.Base
 import Data.Array.Accelerate.LLVM.PTX.CodeGen.Loop
@@ -79,17 +80,18 @@ import Prelude
 --
 mkPermute
     :: HasCallStack
-    => Gamma            aenv
+    => UID
+    -> Gamma            aenv
     -> ArrayR (Array sh e)
     -> ShapeR sh'
     -> IRPermuteFun PTX aenv (e -> e -> e)
     -> IRFun1       PTX aenv (sh -> PrimMaybe sh')
     -> MIRDelayed   PTX aenv (Array sh e)
     -> CodeGen      PTX      (IROpenAcc PTX aenv (Array sh' e))
-mkPermute aenv repr shr' IRPermuteFun{..} project arr =
+mkPermute uid aenv repr shr' IRPermuteFun{..} project arr =
   case atomicRMW of
-    Just (rmw, f) -> mkPermute_rmw   aenv repr shr' rmw f   project arr
-    _             -> mkPermute_mutex aenv repr shr' combine project arr
+    Just (rmw, f) -> mkPermute_rmw   uid aenv repr shr' rmw f   project arr
+    _             -> mkPermute_mutex uid aenv repr shr' combine project arr
 
 
 -- Parallel forward permutation function which uses atomic instructions to
@@ -115,7 +117,8 @@ mkPermute aenv repr shr' IRPermuteFun{..} project arr =
 --
 mkPermute_rmw
     :: HasCallStack
-    => Gamma aenv
+    => UID
+    -> Gamma aenv
     -> ArrayR (Array sh e)
     -> ShapeR sh'
     -> RMWOperation
@@ -123,7 +126,7 @@ mkPermute_rmw
     -> IRFun1     PTX aenv (sh -> PrimMaybe sh')
     -> MIRDelayed PTX aenv (Array sh e)
     -> CodeGen    PTX      (IROpenAcc PTX aenv (Array sh' e))
-mkPermute_rmw aenv (ArrayR shr tp) shr' rmw update project marr = do
+mkPermute_rmw uid aenv (ArrayR shr tp) shr' rmw update project marr = do
   dev <- liftCodeGen $ gets ptxDeviceProperties
   --
   let
@@ -139,7 +142,7 @@ mkPermute_rmw aenv (ArrayR shr tp) shr' rmw update project marr = do
       compute60           = Compute 6 0
       compute70           = Compute 7 0
   --
-  makeOpenAcc "permute_rmw" (paramOut ++ paramIn ++ paramEnv) $ do
+  makeOpenAcc uid "permute_rmw" (paramOut ++ paramIn ++ paramEnv) $ do
 
     shIn  <- delayedExtent arrIn
     end   <- shapeSize shr shIn
@@ -215,14 +218,15 @@ mkPermute_rmw aenv (ArrayR shr tp) shr' rmw update project marr = do
 -- a mutex before updating the value at that location.
 --
 mkPermute_mutex
-    :: Gamma          aenv
+    :: UID
+    -> Gamma          aenv
     -> ArrayR (Array sh e)
     -> ShapeR sh'
     -> IRFun2     PTX aenv (e -> e -> e)
     -> IRFun1     PTX aenv (sh -> PrimMaybe sh')
     -> MIRDelayed PTX aenv (Array sh e)
     -> CodeGen    PTX      (IROpenAcc PTX aenv (Array sh' e))
-mkPermute_mutex aenv (ArrayR shr tp) shr' combine project marr =
+mkPermute_mutex uid aenv (ArrayR shr tp) shr' combine project marr =
   let
       outR                  = ArrayR shr' tp
       lockR                 = ArrayR (ShapeRsnoc ShapeRz) (TupRsingle scalarTypeWord32)
@@ -232,7 +236,7 @@ mkPermute_mutex aenv (ArrayR shr tp) shr' combine project marr =
       paramEnv              = envParam aenv
       start                 = liftInt 0
   in
-  makeOpenAcc "permute_mutex" (paramOut ++ paramLock ++ paramIn ++ paramEnv) $ do
+  makeOpenAcc uid "permute_mutex" (paramOut ++ paramLock ++ paramIn ++ paramEnv) $ do
 
     shIn  <- delayedExtent arrIn
     end   <- shapeSize shr shIn

--- a/accelerate-llvm-ptx/src/Data/Array/Accelerate/LLVM/PTX/CodeGen/Transform.hs
+++ b/accelerate-llvm-ptx/src/Data/Array/Accelerate/LLVM/PTX/CodeGen/Transform.hs
@@ -26,6 +26,7 @@ import Data.Array.Accelerate.LLVM.CodeGen.Environment
 import Data.Array.Accelerate.LLVM.CodeGen.Exp
 import Data.Array.Accelerate.LLVM.CodeGen.Monad
 import Data.Array.Accelerate.LLVM.CodeGen.Sugar
+import Data.Array.Accelerate.LLVM.Compile.Cache                 ( UID )
 
 import Data.Array.Accelerate.LLVM.PTX.CodeGen.Base
 import Data.Array.Accelerate.LLVM.PTX.CodeGen.Loop
@@ -36,19 +37,20 @@ import Data.Array.Accelerate.LLVM.PTX.Target                    ( PTX )
 -- multiple elements, striding the array by the grid size.
 --
 mkTransform
-    :: Gamma       aenv
+    :: UID
+    -> Gamma       aenv
     -> ArrayR (Array sh  a)
     -> ArrayR (Array sh' b)
     -> IRFun1  PTX aenv (sh' -> sh)
     -> IRFun1  PTX aenv (a -> b)
     -> CodeGen PTX      (IROpenAcc PTX aenv (Array sh' b))
-mkTransform aenv repr@(ArrayR shr _) repr'@(ArrayR shr' _) p f =
+mkTransform uid aenv repr@(ArrayR shr _) repr'@(ArrayR shr' _) p f =
   let
       (arrOut, paramOut)  = mutableArray repr' "out"
       (arrIn,  paramIn)   = mutableArray repr  "in"
       paramEnv            = envParam aenv
   in
-  makeOpenAcc "transform" (paramOut ++ paramIn ++ paramEnv) $ do
+  makeOpenAcc uid "transform" (paramOut ++ paramIn ++ paramEnv) $ do
 
     let start = liftInt 0
     end   <- shapeSize shr' (irArrayShape arrOut)

--- a/accelerate-llvm-ptx/src/Data/Array/Accelerate/LLVM/PTX/Execute.hs
+++ b/accelerate-llvm-ptx/src/Data/Array/Accelerate/LLVM/PTX/Execute.hs
@@ -61,6 +61,7 @@ import Data.List                                                ( find )
 import Data.Maybe                                               ( fromMaybe )
 import Text.Printf                                              ( printf )
 import Prelude                                                  hiding ( exp, map, sum, scanl, scanr )
+import qualified Prelude
 
 
 {-# SPECIALISE INLINE executeAcc     :: ExecAcc     PTX      a ->             Par PTX (FutureArraysR PTX a) #-}
@@ -636,7 +637,7 @@ permuteOp inplace repr@(ArrayR shr tp) shr' exe gamma aenv defaults@(shape -> sh
         let paramsR = paramR' `TupRpair` TupRsingle (ParamRfuture $ ParamRarray reprLock) `TupRpair` paramR
         executeOp kernel gamma aenv dim1 ((), n) paramsR ((result, barrier), manifest input)
 
-      _               -> internalError "unexpected kernel image"
+      _               -> internalError ("unexpected kernel image: " ++ B8.unpack (BS.fromShort (kernelName kernel)))
     --
     put future result
     return future
@@ -795,7 +796,7 @@ aforeignOp name _ _ asm arr = do
 --
 (!#) :: HasCallStack => FunctionTable -> ShortByteString -> Kernel
 (!#) exe name
-  = fromMaybe (internalError ("function not found: " ++ unpack name))
+  = fromMaybe (internalError ("function not found: " ++ unpack name ++ " (" ++ show (Prelude.map kernelName (functionTable exe)) ++ ")"))
   $ lookupKernel name exe
 
 lookupKernel :: ShortByteString -> FunctionTable -> Maybe Kernel


### PR DESCRIPTION
<!--
Hi!

Thanks for taking the time to create this pull request! You are awesome (:

The following schema may help when filing your pull request:
-->

## Description
<!--
Provide a description of the pull request here.
Try to include a general summary of the changes in the title above.
-->
This PR attempts to add the hash of the originating AST node to the kernel names in `-ddump-exec` output.

For Native, the symbols in the object files already had the hash included in a <code>\_<i>hash</i></code> suffix (if I understood the code correctly), so it only needed to be preserved in the `FunctionTable`. The lookup function (`lookupFunction`) then needs to strip the hash of the function in the table before comparison.

For PTX, the hash is never included in the name, so it cannot be "preserved" either. Instead, I explicitly added the hash to the names of all kernels; this entails first making sure the hash is available at the point where it needs to be inserted (the first PTX commit), and then actually using that hash when constructing a kernel (the second PTX commit). As before, `lookupKernel` then needs to strip the hash of the kernel name in the table before comparison.

Please view the commits separately; I attempted the separation to make semantic sense. The second Native commit (runQ&MachO) is separate because I'm not sure about its validity.

**Note 1**: The reason why this is still a draft PR is that this change is completely **unconditional** at this point; it should probably be configurable whether this is turned on, and maybe even turned off by default. However, I don't know how to nicely make this configurable; what do you think?

**Note 2**: Because of the change in kernel function names, this PR makes your `~/.cache/accelerate` directory invalid. Please remove it before and after testing this PR.

Please review and provide feedback! Thanks! :)

## Motivation and context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->
This is useful in particular when used together with https://github.com/AccelerateHS/accelerate/pull/478 that includes the hash of an AST node in the pretty-printed output. This then allows linking the timings in the `-ddump-exec` output with the actual AST, which is useful for profiling larger Accelerate programs.

## How has this been tested?
<!--
Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc.
-->
This has been tested in practice on a few large programs. I haven't individually checked that all primitives work as expected, but I didn't find surprises in my usage.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

