### PR TITLE
PTX: Use sync.shfl only on compute capability >= 7.0

### DIFF
--- a/accelerate-llvm-ptx/src/Data/Array/Accelerate/LLVM/PTX/CodeGen/Base.hs
+++ b/accelerate-llvm-ptx/src/Data/Array/Accelerate/LLVM/PTX/CodeGen/Base.hs
@@ -578,11 +578,13 @@ shfl_op sop t delta val = do
       mask :: Operand Int32
       mask  = A.integral integralType (-1) -- all threads participate
 
-      call' = if CUDA.libraryVersion >= 9000
+      useSyncShfl = CUDA.computeCapability dev >= Compute 7 0
+
+      call' = if useSyncShfl
                  then call . Lam primType mask
                  else call
 
-      sync  = if CUDA.computeCapability dev >= Compute 7 0 then "sync." else ""
+      sync  = if useSyncShfl then "sync." else ""
       asm   = "llvm.nvvm.shfl."
            <> sync
            <> case sop of


### PR DESCRIPTION
<!--
Hi!

Thanks for taking the time to create this pull request! You are awesome (:

The following schema may help when filing your pull request:
-->

## Description
Change the check to use `sync.shfl` instead of `shfl` from "CUDA >= 9.0" to "compute capability >= 7.0".

I do not know if this is the correct version bound.

## Motivation and context
Without this change, executing a `fold` or a `scan` on my GTX 1050 Ti (capability 6.1) would print an error in ptxas:

    Feature 'shfl.sync' requires PTX ISA .version 6.0 or later

## How has this been tested?
Folds and scans compile again on my machine.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

