### PR TITLE
Update accelerate-llvm for the new annotation fields from AccelerateHS/accelerate#510

### DIFF
--- a/accelerate-llvm/src/Data/Array/Accelerate/LLVM/AST.hs
+++ b/accelerate-llvm/src/Data/Array/Accelerate/LLVM/AST.hs
@@ -37,6 +37,8 @@ import Data.Array.Accelerate.Type
 -- | Non-computational array program operations, parameterised over array
 -- variables represented as de Bruijn indices.
 --
+-- TODO: Add the annotation fields here
+--
 data PreOpenAccCommand acc arch aenv a where
 
   Avar        :: ArrayVar                   aenv arrs
@@ -192,20 +194,20 @@ data DelayedOpenAcc acc arch aenv a where
 
 instance HasArraysR (acc arch) => HasArraysR (PreOpenAccCommand acc arch) where
   {-# INLINEABLE arraysR #-}
-  arraysR (Avar (Var repr _))                   = TupRsingle repr
-  arraysR (Alet _ _ a)                          = arraysR a
-  arraysR (Alloc repr _)                        = TupRsingle repr
-  arraysR (Use repr _)                          = TupRsingle repr
-  arraysR (Unit tp _)                           = TupRsingle $ ArrayR ShapeRz tp
-  arraysR (Apair a1 a2)                         = arraysR a1 `TupRpair` arraysR a2
-  arraysR Anil                                  = TupRunit
-  arraysR (Atrace _ _ a2)                       = arraysR a2
-  arraysR (Apply repr _ _)                      = repr
-  arraysR (Aforeign repr _ _ _)                 = repr
-  arraysR (Acond _ a1 _)                        = arraysR a1
-  arraysR (Awhile _ _ a)                        = arraysR a
-  arraysR (Reshape shr _ (Var (ArrayR _ tp) _)) = TupRsingle $ ArrayR shr tp
-  arraysR (Unzip idx (Var (ArrayR shr tp) _))   = TupRsingle $ ArrayR shr $ go idx tp
+  arraysR (Avar (Var _ repr _))                   = TupRsingle repr
+  arraysR (Alet _ _ a)                            = arraysR a
+  arraysR (Alloc repr _)                          = TupRsingle repr
+  arraysR (Use repr _)                            = TupRsingle repr
+  arraysR (Unit tp _)                             = TupRsingle $ ArrayR ShapeRz tp
+  arraysR (Apair a1 a2)                           = arraysR a1 `TupRpair` arraysR a2
+  arraysR Anil                                    = TupRunit
+  arraysR (Atrace _ _ a2)                         = arraysR a2
+  arraysR (Apply repr _ _)                        = repr
+  arraysR (Aforeign repr _ _ _)                   = repr
+  arraysR (Acond _ a1 _)                          = arraysR a1
+  arraysR (Awhile _ _ a)                          = arraysR a
+  arraysR (Reshape shr _ (Var _ (ArrayR _ tp) _)) = TupRsingle $ ArrayR shr tp
+  arraysR (Unzip idx (Var _ (ArrayR shr tp) _))   = TupRsingle $ ArrayR shr $ go idx tp
     where
       go :: UnzipIdx a b -> TypeR a -> TypeR b
       go UnzipId                    t              = t

--- a/accelerate-llvm/src/Data/Array/Accelerate/LLVM/CodeGen/Environment.hs
+++ b/accelerate-llvm/src/Data/Array/Accelerate/LLVM/CodeGen/Environment.hs
@@ -90,5 +90,4 @@ makeGamma = snd . IM.mapAccum (\n ix -> (n+1, toAval n ix)) 0
 -- | A free variable
 --
 freevar :: ArrayVar aenv a -> IntMap (Idx' aenv)
-freevar (Var repr@ArrayR{} ix) = IM.singleton (idxToInt ix) (Idx' repr ix)
-
+freevar (Var _ repr@ArrayR{} ix) = IM.singleton (idxToInt ix) (Idx' repr ix)

--- a/accelerate-llvm/src/Data/Array/Accelerate/LLVM/CodeGen/Permute.hs
+++ b/accelerate-llvm/src/Data/Array/Accelerate/LLVM/CodeGen/Permute.hs
@@ -115,7 +115,7 @@ llvmOfPermuteFun fun aenv = IRPermuteFun{..}
       -- atomic compare-and-swap, which is likely to be more performant than the
       -- generic spin-lock based approach.
       --
-      | Lam lhs@(LeftHandSideSingle _) (Lam (LeftHandSideSingle _) (Body body)) <- fun
+      | Lam lhs@(LeftHandSideSingle _ _) (Lam (LeftHandSideSingle _ _) (Body body)) <- fun
       , Just (rmw, x)         <- rmwOp body
       , Just x'               <- strengthenE latest x
       , fun'                  <- llvmOfFun1 (Lam lhs (Body x')) aenv
@@ -135,7 +135,7 @@ llvmOfPermuteFun fun aenv = IRPermuteFun{..}
     --    TLM-2019-09-27
     --
     rmwOp :: OpenExp (((),e),e) aenv e -> Maybe (RMWOperation, OpenExp (((),e),e) aenv e)
-    rmwOp (PrimApp f xs)
+    rmwOp (PrimApp _ f xs)
       | PrimAdd{}  <- f = (RMW.Add,) <$> extract xs
       | PrimSub{}  <- f = (RMW.Sub,) <$> extract xs
       | PrimMin{}  <- f = (RMW.Min,) <$> extract xs
@@ -154,9 +154,9 @@ llvmOfPermuteFun fun aenv = IRPermuteFun{..}
     -- argument, corresponding to ZeroIdx.
     --
     extract :: OpenExp (((),e),e) aenv (e,e) -> Maybe (OpenExp (((),e),e) aenv e)
-    extract (Pair x y)
-      | Evar (Var _ ZeroIdx) <- x = Just y
-      | Evar (Var _ ZeroIdx) <- y = Just x
+    extract (Pair _ x y)
+      | Evar (Var _ _ ZeroIdx) <- x = Just y
+      | Evar (Var _ _ ZeroIdx) <- y = Just x
     extract _
       = Nothing
 

--- a/accelerate-llvm/src/Data/Array/Accelerate/LLVM/Embed.hs
+++ b/accelerate-llvm/src/Data/Array/Accelerate/LLVM/Embed.hs
@@ -27,6 +27,7 @@ module Data.Array.Accelerate.LLVM.Embed (
 
 import LLVM.AST.Type.Name
 
+import Data.Array.Accelerate.Annotations
 import Data.Array.Accelerate.AST                                    ( PreOpenAfun(..), ArrayVar, Direction(..), Exp, liftALeftHandSide, liftOpenExp, liftMessage, arraysR, arrayR )
 import Data.Array.Accelerate.AST.Idx
 import Data.Array.Accelerate.AST.Var
@@ -215,7 +216,7 @@ liftPreOpenAccSkeleton arch pacc =
     Stencil2 tp h a b    -> [|| Stencil2 $$(liftTypeR tp) $$(liftS (arrayRshape $ arrayR a) h) $$(liftD a) $$(liftD b) ||]
 
 liftArrayVar :: ArrayVar aenv v -> CodeQ (ArrayVar aenv v)
-liftArrayVar (Var tp v) = [|| Var $$(liftArrayR tp) $$(liftIdx v) ||]
+liftArrayVar (Var ann tp v) = [|| Var $$(liftAnn ann) $$(liftArrayR tp) $$(liftIdx v) ||]
 
 liftUnzipIdx :: UnzipIdx tup e -> CodeQ (UnzipIdx tup e)
 liftUnzipIdx UnzipId                    = [|| UnzipId ||]

--- a/accelerate-llvm/src/Data/Array/Accelerate/LLVM/Execute/Environment.hs
+++ b/accelerate-llvm/src/Data/Array/Accelerate/LLVM/Execute/Environment.hs
@@ -33,12 +33,12 @@ data ValR arch env where
   Push  :: ValR arch env -> FutureR arch t -> ValR arch (env, t)
 
 push :: ValR arch env -> (ALeftHandSide t env env', FutureArraysR arch t) -> ValR arch env'
-push env (LeftHandSideWildcard _     , _       ) = env
-push env (LeftHandSideSingle ArrayR{}, a       ) = env `Push` a
-push env (LeftHandSidePair l1 l2     , (a1, a2)) = push env (l1, a1) `push` (l2, a2)
+push env (LeftHandSideWildcard _       , _       ) = env
+push env (LeftHandSideSingle _ ArrayR{}, a       ) = env `Push` a
+push env (LeftHandSidePair l1 l2       , (a1, a2)) = push env (l1, a1) `push` (l2, a2)
 
 pushE :: Async arch => ValR arch env -> (ELeftHandSide t env env', FutureR arch t) -> Par arch (ValR arch env')
-pushE env (LeftHandSideSingle _  , e) = return $ env `Push` e
+pushE env (LeftHandSideSingle _ _, e) = return $ env `Push` e
 pushE env (LeftHandSideWildcard _, _) = return env
 pushE env (LeftHandSidePair l1 l2, e) = do
   -- TODO: This code creates many intermediate Futures, in case of deeply nested pairs.

--- a/cabal.project
+++ b/cabal.project
@@ -4,10 +4,11 @@ packages: accelerate-llvm
 
 source-repository-package
     type: git
-    location: https://github.com/AccelerateHS/accelerate.git
-    tag: 20cd26291f42b2ea74d4e9750301620f83f98b17
+    location: https://github.com/robbert-vdh/accelerate.git
+    tag: 40bf37354de5249820190dd732775a3ad91707d7
     -- Cabal builds from an sdist, and `accelerate.cabal` references files that
     -- don't exist on a fresh clone. Cabal 3.8.0.0 will do this automatically.
+    --
     -- XXX: For some reason cabal just stops when the command returns 0? So
     --      negating this seems to 'work'
     post-checkout-command: bash -c "! git submodule update --init --recursive"
@@ -17,8 +18,10 @@ source-repository-package
 source-repository-package
     type: git
     location: https://github.com/llvm-hs/llvm-hs.git
-    tag: 351683ed1c2f6b329e62439d42a158b1d804b846
+    tag: eda85a2bbe362a0b89df5adce0cb65e4e755eac5
     subdir: llvm-hs llvm-hs-pure
 
 -- package accelerate
 --     flags: +debug
+
+-- vim: nospell syntax=cabal

--- a/stack-8.10.yaml
+++ b/stack-8.10.yaml
@@ -2,7 +2,7 @@
 # For advanced use and comprehensive documentation of the format, please see:
 # https://docs.haskellstack.org/en/stable/yaml_configuration/
 
-resolver: lts-18.0
+resolver: lts-18.25
 
 packages:
 - accelerate-llvm
@@ -10,8 +10,8 @@ packages:
 - accelerate-llvm-ptx
 
 extra-deps:
-- github: AccelerateHS/accelerate
-  commit: 20cd26291f42b2ea74d4e9750301620f83f98b17
+- github: robbert-vdh/accelerate
+  commit: 99010598cacfeefd87d426c9c0ae6a18a5108be6
 
 - cuda-0.10.2.0
 - nvvm-0.10.0.0

--- a/stack-8.6.yaml
+++ b/stack-8.6.yaml
@@ -9,8 +9,8 @@ packages:
 - accelerate-llvm-ptx
 
 extra-deps:
-- github: AccelerateHS/accelerate
-  commit: 20cd26291f42b2ea74d4e9750301620f83f98b17
+- github: robbert-vdh/accelerate
+  commit: 40bf37354de5249820190dd732775a3ad91707d7
 
 - cuda-0.10.2.0
 - formatting-7.1.3

--- a/stack-8.8.yaml
+++ b/stack-8.8.yaml
@@ -9,8 +9,8 @@ packages:
 - accelerate-llvm-ptx
 
 extra-deps:
-- github: AccelerateHS/accelerate
-  commit: 20cd26291f42b2ea74d4e9750301620f83f98b17
+- github: robbert-vdh/accelerate
+  commit: 40bf37354de5249820190dd732775a3ad91707d7
 
 - cuda-0.10.2.0
 - formatting-7.1.3

--- a/stack-9.0.yaml
+++ b/stack-9.0.yaml
@@ -2,7 +2,7 @@
 # For advanced use and comprehensive documentation of the format, please see:
 # https://docs.haskellstack.org/en/stable/yaml_configuration/
 
-resolver: nightly-2021-07-09
+resolver: nightly-2022-02-16
 
 packages:
 - accelerate-llvm
@@ -10,17 +10,21 @@ packages:
 - accelerate-llvm-ptx
 
 extra-deps:
-- github: AccelerateHS/accelerate
-  commit: 20cd26291f42b2ea74d4e9750301620f83f98b17
+- github: robbert-vdh/accelerate
+  commit: 40bf37354de5249820190dd732775a3ad91707d7
 
 - github: llvm-hs/llvm-hs
-  commit: 351683ed1c2f6b329e62439d42a158b1d804b846
+  commit: eda85a2bbe362a0b89df5adce0cb65e4e755eac5
   subdirs:
     - llvm-hs
     - llvm-hs-pure
 
 # Override default flag values for local packages and extra-deps
 # flags: {}
+
+# Extra per-package and global ghc options
+# ghc-options:
+#   llvm-hs: -optcxx=-std=c++14 -optcxx=-lstdc++ -optcxx=-fno-rtti
 
 # Extra package databases containing global packages
 # extra-package-dbs: []


### PR DESCRIPTION
## Description
This simply adds holes to make `accelerate-llvm*` compile again with the changes from https://github.com/AccelerateHS/accelerate/pull/510. Once that PR has been merged, the pinned commit in the `stack.yaml` files will need to be updated. I will be working on using these annotations to add more useful context to the Tracy integration after this.

## Motivation and context
Having accelerate-llvm compile without any errors sounds pretty great.

## How has this been tested?
With the same environment mentioned in the other PR. Since this doesn't change any functionality, it's only a matter of making sure it compiles under the supported GHC versions. That being said, the macOS CI jobs still fail because llvm-hs can't determine the version of LLVM installed by homebrew, and the Linux jobs fail because they mysteriously produce the wrong results just like they do on the current master branch. That probably needs to be fixed at some point.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed. - The tests failed before this, and they still fail.