### PR TITLE
Add a Cabal project file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 dist
+dist-newstyle
 cabal-dev
 *.o
 *.hi
@@ -7,6 +8,7 @@ cabal-dev
 .virthualenv
 *.swp
 .cabal-sandbox
+cabal.project.local*
 cabal.sandbox.config
 .stack-work
 stack.yaml

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,24 @@
+packages: accelerate-llvm
+          accelerate-llvm-native
+          accelerate-llvm-ptx
+
+source-repository-package
+    type: git
+    location: https://github.com/AccelerateHS/accelerate.git
+    tag: 20cd26291f42b2ea74d4e9750301620f83f98b17
+    -- Cabal builds from an sdist, and `accelerate.cabal` references files that
+    -- don't exist on a fresh clone. Cabal 3.8.0.0 will do this automatically.
+    -- XXX: For some reason cabal just stops when the command returns 0? So
+    --      negating this seems to 'work'
+    post-checkout-command: bash -c "! git submodule update --init --recursive"
+
+-- This is for LLVM 12, comment this stanza out to fall back to the latest
+-- versions of these packages published to Hackage
+source-repository-package
+    type: git
+    location: https://github.com/llvm-hs/llvm-hs.git
+    tag: 351683ed1c2f6b329e62439d42a158b1d804b846
+    subdir: llvm-hs llvm-hs-pure
+
+-- package accelerate
+--     flags: +debug

--- a/stack-8.10.yaml
+++ b/stack-8.10.yaml
@@ -10,8 +10,8 @@ packages:
 - accelerate-llvm-ptx
 
 extra-deps:
-- github: tmcdonell/accelerate
-  commit: 8655a01f06812a243afcbdc7649737e54edbd548
+- github: AccelerateHS/accelerate
+  commit: 20cd26291f42b2ea74d4e9750301620f83f98b17
 
 - cuda-0.10.2.0
 - nvvm-0.10.0.0

--- a/stack-8.6.yaml
+++ b/stack-8.6.yaml
@@ -9,8 +9,8 @@ packages:
 - accelerate-llvm-ptx
 
 extra-deps:
-- github: tmcdonell/accelerate
-  commit: 8655a01f06812a243afcbdc7649737e54edbd548
+- github: AccelerateHS/accelerate
+  commit: 20cd26291f42b2ea74d4e9750301620f83f98b17
 
 - cuda-0.10.2.0
 - formatting-7.1.3

--- a/stack-8.8.yaml
+++ b/stack-8.8.yaml
@@ -9,8 +9,8 @@ packages:
 - accelerate-llvm-ptx
 
 extra-deps:
-- github: tmcdonell/accelerate
-  commit: 8655a01f06812a243afcbdc7649737e54edbd548
+- github: AccelerateHS/accelerate
+  commit: 20cd26291f42b2ea74d4e9750301620f83f98b17
 
 - cuda-0.10.2.0
 - formatting-7.1.3

--- a/stack-9.0.yaml
+++ b/stack-9.0.yaml
@@ -10,8 +10,8 @@ packages:
 - accelerate-llvm-ptx
 
 extra-deps:
-- github: tmcdonell/accelerate
-  commit: 7c769b761d0b2a91f318096b9dd3fced94616961
+- github: AccelerateHS/accelerate
+  commit: 20cd26291f42b2ea74d4e9750301620f83f98b17
 
 - github: llvm-hs/llvm-hs
   commit: 351683ed1c2f6b329e62439d42a158b1d804b846


### PR DESCRIPTION
## Description
This allows building accelerate-llvm with plain Cabal as an alternative to using Stack. The bump to the targeted Accelerate version to include https://github.com/AccelerateHS/accelerate/pull/511, as Cabal builds source dependencies from an sdist just like any other dependency instead of building them as a local package.

## Motivation and context
Over the years Cabal has caught up to Stack in terms of features (other than handling multiple GHC versions, which is covered by `ghcup`), and I've personally been having way fewer mysterious issues with Cabal than with Stack. Builds seem to be faster with Cabal (presumably because more dependencies are being cached), and with Stack I've frequently ran into the situation where the only way to fix the build was to remove `~/.stack` and let it redownload everything again. This mostly happened when a compiler error interrupts the build for `llvm-hs` causing lingering linking issues that can't be solved in any obvious way I've tried, or when changing flags on the Accelerate package which Stack somehow tends to ignore unless you manually unregister the package yourself. So far Cabal 3.6.2.0 has been chugging along nicely (fingers crossed).

## How has this been tested?
By building `accelerate-llvm-native` and `accelerate-llvm-ptx` with GHC 8.10.7 and Cabal 3.6.2.0 from ghcup using `cabal build -j accelerate-llvm-native accelerate-llvm-ptx`.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed. (the tests already failed, and they still fail)

