### PR TITLE
accelerate-llvm-ptx: Fix a bug in 'permuteOp'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ tags
 local/
 /stack.yaml.lock
 .ipynb_checkpoints
+dist-newstyle/

--- a/accelerate-llvm-ptx/src/Data/Array/Accelerate/LLVM/PTX/Execute.hs
+++ b/accelerate-llvm-ptx/src/Data/Array/Accelerate/LLVM/PTX/Execute.hs
@@ -620,7 +620,10 @@ permuteOp inplace repr@(ArrayR shr tp) shr' exe gamma aenv defaults@(shape -> sh
                  then Debug.trace Debug.dump_exec "exec: permute/inplace" $ return defaults
                  else Debug.trace Debug.dump_exec "exec: permute/clone"   $ get =<< cloneArrayAsync repr' defaults
     --
-    case kernelName kernel of
+    let kernelName' =
+          let kn = kernelName kernel
+          in S.take (S.length kn - 65) kn
+    case kernelName' of
       -- execute directly using atomic operations
       "permute_rmw"   ->
         let paramsR = paramR' `TupRpair` paramR


### PR DESCRIPTION
<!--
Hi!

Thanks for taking the time to create this pull request! You are awesome (:

The following schema may help when filing your pull request:
-->

## Description
<!--
Provide a description of the pull request here.
Try to include a general summary of the changes in the title above.
-->

Change `Data.Array.Accelerate.LLVM.PTX.Execute.permuteOp` to drop the last 65 characters of the kernel name before matching on it.

## Motivation and context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

`permuteOp` matches on the kernel name without taking into account the [UID that is appended to it](https://github.com/AccelerateHs/accelerate-llvm/commit/755810cd83c99d99f6716d228b2e1461313f0d9b).

## How has this been tested?
<!--
Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc.
-->

I have a program that crashed with "unexpected kernel image" in `permuteOp`. The kernel image was `permute_rmw_3ab3db10c4bf12531b0113ab99bf596bf423c5fe27ca86c8ce601bfd4656a965`. After applying the fix the program ran through without crashing.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

