### PR TITLE
Fix build under LLVM 13

### DIFF
--- a/accelerate-llvm-native/accelerate-llvm-native.cabal
+++ b/accelerate-llvm-native/accelerate-llvm-native.cabal
@@ -126,8 +126,8 @@ Library
         , ghc
         , hashable                      >= 1.0
         , libffi                        >= 0.1
-        , llvm-hs                       >= 4.1 && < 13
-        , llvm-hs-pure                  >= 4.1 && < 13
+        , llvm-hs                       >= 4.1 && < 14
+        , llvm-hs-pure                  >= 4.1 && < 14
         , lockfree-queue                >= 0.2
         , mtl                           >= 2.2.1
         , template-haskell

--- a/accelerate-llvm-ptx/accelerate-llvm-ptx.cabal
+++ b/accelerate-llvm-ptx/accelerate-llvm-ptx.cabal
@@ -141,8 +141,8 @@ Library
         , filepath                      >= 1.0
         , formatting                    >= 7.0
         , hashable                      >= 1.2
-        , llvm-hs                       >= 4.1 && < 13
-        , llvm-hs-pure                  >= 4.1 && < 13
+        , llvm-hs                       >= 4.1 && < 14
+        , llvm-hs-pure                  >= 4.1 && < 14
         , mtl                           >= 2.2.1
         , nvvm                          >= 0.9
         , prettyprinter                 >= 1.6.1

--- a/accelerate-llvm/accelerate-llvm.cabal
+++ b/accelerate-llvm/accelerate-llvm.cabal
@@ -150,8 +150,8 @@ Library
         , filepath                      >= 1.0
         , formatting                    >= 7.0
         , hashable                      >= 1.1
-        , llvm-hs                       >= 4.1 && < 13
-        , llvm-hs-pure                  >= 4.1 && < 13
+        , llvm-hs                       >= 4.1 && < 14
+        , llvm-hs-pure                  >= 4.1 && < 14
         , mtl                           >= 2.0
         , primitive                     >= 0.6.4
         , template-haskell


### PR DESCRIPTION
## Description
The `cmpxchg` and `atomicrmw` instructions now have optional alignment parameters. Leaving these at 0 will default the alignment to the size of the type. Upstream `llvm-hs` needs one small [patch](https://github.com/llvm-hs/llvm-hs/pull/374) to fix the build under LLVM 13.

I've tested this with the following llvm-hs version:

```
source-repository-package
    type: git
    location: https://github.com/robbert-vdh/llvm-hs.git
    tag: 1a69805f63fdd175377f2f35290101f71c0c296d
    subdir: llvm-hs llvm-hs-pure
```

## Motivation and context
LLVM 13 has been released on October 4th and a lot of distros are already packaging it.

## How has this been tested?
I've tested this with GHC 8.10.7, Cabal 3.6.2.0, and the llvm-hs version mentioned above.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed. (they already didn't pass, and they still don't pass)

