### PR TITLE
Enable support for latest llvm-hs (LLVM-15) and ghc (GHC 9.4.2).

### DIFF
--- a/accelerate-llvm-native/Setup.hs
+++ b/accelerate-llvm-native/Setup.hs
@@ -7,6 +7,7 @@ import Distribution.PackageDescription.PrettyPrint
 import Distribution.Simple
 import Distribution.Simple.BuildPaths
 import Distribution.Simple.LocalBuildInfo
+import Distribution.Simple.PackageDescription
 import Distribution.Simple.PackageIndex
 import Distribution.Simple.Setup                                    as Setup
 import Distribution.Verbosity

--- a/accelerate-llvm-native/accelerate-llvm-native.cabal
+++ b/accelerate-llvm-native/accelerate-llvm-native.cabal
@@ -134,14 +134,15 @@ Library
         , ghc
         , hashable                      >= 1.0
         , libffi                        >= 0.1
-        , llvm-hs                       >= 4.1 && < 14
-        , llvm-hs-pure                  >= 4.1 && < 14
+        , llvm-hs                       >= 4.1 && < 16
+        , llvm-hs-pure                  >= 4.1 && < 16
         , lockfree-queue                >= 0.2
         , mtl                           >= 2.2.1
           -- TODO: These are only used for lifting ByteStrings. bytestring
           --       0.11.2.0 include its own, better lifting instances. Once
           --       that's stable, we can remove this dependency and bump
           --       bytestring's version bound.
+        , process
         , th-lift-instances
         , template-haskell
         , text                          >= 1.2

--- a/accelerate-llvm-native/src/Data/Array/Accelerate/LLVM/Native/Execute/Marshal.hs
+++ b/accelerate-llvm-native/src/Data/Array/Accelerate/LLVM/Native/Execute/Marshal.hs
@@ -34,6 +34,6 @@ import qualified Foreign.LibFFI                                 as FFI
 instance Marshal Native where
   type ArgR Native = FFI.Arg
 
-  marshalInt = FFI.argInt
+  marshalInt = FFI.argCInt . fromIntegral
   marshalScalarData' _ = return . DL.singleton . FFI.argPtr . unsafeUniqueArrayPtr
 

--- a/accelerate-llvm-native/src/Data/Array/Accelerate/LLVM/Native/Link/Cache.hs
+++ b/accelerate-llvm-native/src/Data/Array/Accelerate/LLVM/Native/Link/Cache.hs
@@ -22,8 +22,12 @@ import Data.Array.Accelerate.LLVM.Native.Link.Object
 import qualified Data.Array.Accelerate.LLVM.Link.Cache              as LC
 
 import Control.Monad
-import System.Posix.DynamicLinker
 
+#if defined(mingw32_HOST_OS)
+import System.Win32.DLL
+#else
+import System.Posix.DynamicLinker
+#endif
 
 type LinkCache = LC.LinkCache FunctionTable ObjectCode
 
@@ -43,6 +47,10 @@ new = do
   -- Accelerate library) causes segfaults; possibly because the RTS was
   -- otherwise linked statically into the executable.
   --
-  when debuggingIsEnabled $ void $ dlopen ACCELERATE_DYLD_LIBRARY_PATH [RTLD_LAZY, RTLD_GLOBAL]
+  when debuggingIsEnabled $ void $
+#if defined(mingw32_HOST_OS)
+    loadLibrary ACCELERATE_DYLD_LIBRARY_PATH
+#else
+    dlopen ACCELERATE_DYLD_LIBRARY_PATH [RTLD_LAZY, RTLD_GLOBAL]
+#endif
   LC.new
-

--- a/accelerate-llvm-native/src/Data/Array/Accelerate/LLVM/Native/Link/Object.hs
+++ b/accelerate-llvm-native/src/Data/Array/Accelerate/LLVM/Native/Link/Object.hs
@@ -21,6 +21,7 @@ import Data.Array.Accelerate.Lifetime
 
 #if defined(mingw32_HOST_OS)
 import System.Win32.DLL
+import System.Win32.Types
 #else
 import System.Posix.DynamicLinker
 #endif

--- a/accelerate-llvm-native/src/Data/Array/Accelerate/LLVM/Native/Link/Runtime.hs
+++ b/accelerate-llvm-native/src/Data/Array/Accelerate/LLVM/Native/Link/Runtime.hs
@@ -28,10 +28,11 @@ import qualified Data.Array.Accelerate.LLVM.Native.Debug            as Debug
 import Control.Monad
 import Data.ByteString.Short.Char8                                  ( ShortByteString )
 import Formatting
+import Foreign.Ptr
 import qualified Data.ByteString.Short.Char8                        as B8
 
 #if defined(mingw32_HOST_OS)
-#error "Dynamic linking not implemented yet"
+import System.Win32.DLL
 #else
 import System.Posix.DynamicLinker
 #endif
@@ -45,6 +46,23 @@ import System.Posix.DynamicLinker
 --
 loadSharedObject :: HasCallStack => [ShortByteString] -> FilePath -> IO (FunctionTable, ObjectCode)
 loadSharedObject nms path = do
+#if defined(mingw32_HOST_OS)
+  dll      <- loadLibrary path
+  fun_tab <- fmap FunctionTable $ forM nms $ \nm -> do
+    let s = B8.unpack nm
+    Debug.traceM Debug.dump_ld ("ld: looking up symbol " % string) s
+    sym <- getProcAddress dll s
+    return (nm, castPtrToFunPtr sym)
+
+  object_code <- newLifetime dll
+  addFinalizer object_code $ do
+    -- XXX: Should we disable unloading objects in debug mode? Tracy might
+    -- still need access to e.g. embedded string data
+    Debug.traceM Debug.dump_gc ("gc: unload module: " % formatFunctionTable) fun_tab
+    freeLibrary dll
+
+  return (fun_tab, object_code)
+#else
   so      <- dlopen path [RTLD_LAZY, RTLD_LOCAL]
   fun_tab <- fmap FunctionTable $ forM nms $ \nm -> do
     let s = B8.unpack nm
@@ -60,4 +78,4 @@ loadSharedObject nms path = do
     dlclose so
 
   return (fun_tab, object_code)
-
+#endif

--- a/accelerate-llvm/accelerate-llvm.cabal
+++ b/accelerate-llvm/accelerate-llvm.cabal
@@ -150,8 +150,8 @@ Library
         , filepath                      >= 1.0
         , formatting                    >= 7.0
         , hashable                      >= 1.1
-        , llvm-hs                       >= 4.1 && < 14
-        , llvm-hs-pure                  >= 4.1 && < 14
+        , llvm-hs                       >= 4.1 && < 16
+        , llvm-hs-pure                  >= 4.1 && < 16
         , mtl                           >= 2.0
         , primitive                     >= 0.6.4
         , template-haskell

--- a/accelerate-llvm/src/Data/ByteString/Short/Extra.hs
+++ b/accelerate-llvm/src/Data/ByteString/Short/Extra.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE BangPatterns    #-}
+{-# LANGUAGE CPP             #-}
 {-# LANGUAGE MagicHash       #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE UnboxedTuples   #-}
@@ -16,8 +17,10 @@
 module Data.ByteString.Short.Extra (
 
   ShortByteString,
+#if !MIN_VERSION_bytestring(0,11,3)
   take,
   takeWhile,
+#endif
   liftSBS,
 
 ) where
@@ -36,6 +39,8 @@ import GHC.ST
 import GHC.Exts
 import GHC.Word
 
+
+#if !MIN_VERSION_bytestring(0,11,3)
 
 -- | /O(n)/ @'take' n@ applied to the ShortByteString @xs@, returns the prefix
 -- of @xs@ of length @n@ as a new ShortByteString, or @xs@ itself if
@@ -58,6 +63,7 @@ take n xs
 takeWhile :: (Word8 -> Bool) -> ShortByteString -> ShortByteString
 takeWhile f ps = take (findIndexOrEnd (not . f) ps) ps
 
+#endif
 
 -- | Return the index of the first element satisfying the predicate, otherwise
 -- return the length of the string if no such element is found.

--- a/accelerate-llvm/src/LLVM/AST/Type/Constant.hs
+++ b/accelerate-llvm/src/LLVM/AST/Type/Constant.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP                   #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE GADTs                 #-}
 {-# LANGUAGE LambdaCase            #-}
@@ -66,7 +67,11 @@ data Constant a where
 instance Downcast (Constant a) LLVM.Constant where
   downcast = \case
     UndefConstant t       -> LLVM.Undef (downcast t)
+#if MIN_VERSION_llvm_hs(15,0,0)
+    GlobalReference _ n   -> LLVM.GlobalReference (downcast n)
+#else
     GlobalReference t n   -> LLVM.GlobalReference (downcast t) (downcast n)
+#endif
     BooleanConstant x     -> LLVM.Int 1 (toInteger (fromEnum x))
     NullPtrConstant t     -> LLVM.Null (downcast t)
     ScalarConstant t x    -> scalar t x

--- a/accelerate-llvm/src/LLVM/AST/Type/Representation.hs
+++ b/accelerate-llvm/src/LLVM/AST/Type/Representation.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP                   #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE GADTs                 #-}
 {-# LANGUAGE LambdaCase            #-}
@@ -359,7 +360,11 @@ instance Downcast (PrimType a) LLVM.Type where
   downcast BoolPrimType         = LLVM.IntegerType 1
   downcast (NamedPrimType t)    = LLVM.NamedTypeReference (downcast t)
   downcast (ScalarPrimType t)   = downcast t
-  downcast (PtrPrimType t a)    = LLVM.PointerType (downcast t) a
+#if MIN_VERSION_llvm_hs_pure(15,0,0)
+  downcast (PtrPrimType _ a)    = LLVM.PointerType a
+#else
+  downcast (PtrPrimType t a)    = LLVM.PointerType (downcast t) a``
+#endif
   downcast (ArrayPrimType n t)  = LLVM.ArrayType n (downcast t)
   downcast (StructPrimType p t) = LLVM.StructureType p (go t)
     where


### PR DESCRIPTION
## Description

Adapt to latest LLVM (the `llvm-15` branch in llvm-hs), and latest ghc (9.4.2), see also https://github.com/llvm-hs/llvm-hs/pull/411.

This pull requests fixes some Windows related TODOs as well.

## How has this been tested?

This pull request has been tested on Windows with MSYS2 and latest LLVM and GHC.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

No breaking change introduced, and fully backwards compatible with previous versions of `llvm-hs`, `ghc`, `bytestring`, etc.

