### PR TITLE
Add syncthreads to scans prevent overwriting shared memory of previous chunk

### DIFF
--- a/accelerate-llvm-ptx/src/Data/Array/Accelerate/LLVM/PTX/CodeGen/Scan.hs
+++ b/accelerate-llvm-ptx/src/Data/Array/Accelerate/LLVM/PTX/CodeGen/Scan.hs
@@ -189,6 +189,10 @@ mkScanAllP1 dir uid aenv tp combine mseed marr = do
     -- iterating over thread-block-wide segments
     imapFromStepTo s0 gd' end $ \chunk -> do
 
+      -- Make sure all threads have finished previous iterations,
+      -- so we can reuse (and overwrite) shared memory.
+      __syncthreads
+
       bd    <- blockDim
       bd'   <- int bd
       inf   <- A.mul numType chunk bd'
@@ -498,6 +502,10 @@ mkScan'AllP1 dir uid aenv tp combine seed marr = do
 
     -- iterate over thread-block wide segments
     imapFromStepTo bid gd end $ \seg -> do
+
+      -- Make sure all threads have finished previous iterations,
+      -- so we can reuse (and overwrite) shared memory.
+      __syncthreads
 
       bd  <- int =<< blockDim
       inf <- A.mul numType seg bd
@@ -818,6 +826,10 @@ mkScanDim dir uid aenv repr@(ArrayR (ShapeRsnoc shr) tp) combine mseed marr = do
     end <- shapeSize shr (indexTail (irArrayShape arrOut))
 
     imapFromStepTo bid gd end $ \seg -> do
+
+      -- Make sure all threads have finished previous iterations,
+      -- so we can reuse (and overwrite) shared memory.
+      __syncthreads
 
       -- Index this thread reads from
       tid   <- threadIdx


### PR DESCRIPTION

<!--
Hi!

Thanks for taking the time to create this pull request! You are awesome (:

The following schema may help when filing your pull request:
-->

## Description
<!--
Provide a description of the pull request here.
Try to include a general summary of the changes in the title above.
-->
This PR fixes an issue that we had for a long time. Programs with scans would sometimes give incorrect values. As I found out, this is caused by missing synchronization in thread groups in the scan kernels.

## Motivation and context
<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->
A thread group in a scan kernel may handle multiple chunks of the input. 
A __syncthreads was missing between the end of one chunk and the start of the next, which caused that
shared memory could be overwritten in in the next iteration, before all threads are finished reading data from the previous iteration.
scanBlockShfl does perform synchronisation between its writes and reads, but there was no synchronisation between the reads of some iteration of the outer loop, and the writes in the next iteration.

## How has this been tested?
<!--
Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc.
-->
Our quickhull implementation now works correctly on the GPU, whereas it previously would produce garbage values or crash (as it continues to compute with those garbage values). This was tested on an A100 and 4090.

## Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
-->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

