### PR TITLE
remove unnecessary llvm targets from compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,10 +104,10 @@ If your OS does not have an appropriate LLVM distribution available, you can als
      `$HOME/opt/llvm`: (you can skip the `;NVPTX` if you're not interested in
      using `accelerate-llvm-ptx`)
      ```sh
-     $ cmake $LLVM_SRC -DCMAKE_INSTALL_PREFIX=$INSTALL_PREFIX -DCMAKE_BUILD_TYPE=Release -DLLVM_BUILD_LLVM_DYLIB=ON -DLLVM_LINK_LLVM_DYLIB=ON -DLLVM_TARGETS_TO_BUILD='X86;NVPTX' -DLLVM_ENABLE_PROJECTS=''
+     $ cmake $LLVM_SRC -DCMAKE_INSTALL_PREFIX=$INSTALL_PREFIX -DCMAKE_BUILD_TYPE=Release -DLLVM_INCLUDE_BENCHMARKS=OFF -DLLVM_BUILD_LLVM_DYLIB=ON -DLLVM_LINK_LLVM_DYLIB=ON -DLLVM_TARGETS_TO_BUILD='X86;NVPTX' -DLLVM_ENABLE_PROJECTS=''
      ```
      See [options and variables](http://llvm.org/docs/CMake.html#options-and-variables)
-     for a list of additional build parameters you can specify.
+     for a list of additional build parameters you can specify. (You may also need [extra CMake modules](https://github.com/llvm/llvm-project/issues/56971#issuecomment-1207180969)).
 
   4. Build and install:
      ```sh

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ If your OS does not have an appropriate LLVM distribution available, you can als
      `$HOME/opt/llvm`: (you can skip the `;NVPTX` if you're not interested in
      using `accelerate-llvm-ptx`)
      ```sh
-     $ cmake $LLVM_SRC -DCMAKE_INSTALL_PREFIX=$INSTALL_PREFIX -DCMAKE_BUILD_TYPE=Release -DLLVM_BUILD_LLVM_DYLIB=ON -DLLVM_LINK_LLVM_DYLIB=ON -DLLVM_TARGETS_TO_BUILD='X86;NVPTX' -DLLVM_ENABLE_PROJECTS='clang;libcxx;libcxxabi'
+     $ cmake $LLVM_SRC -DCMAKE_INSTALL_PREFIX=$INSTALL_PREFIX -DCMAKE_BUILD_TYPE=Release -DLLVM_BUILD_LLVM_DYLIB=ON -DLLVM_LINK_LLVM_DYLIB=ON -DLLVM_TARGETS_TO_BUILD='X86;NVPTX' -DLLVM_ENABLE_PROJECTS=''
      ```
      See [options and variables](http://llvm.org/docs/CMake.html#options-and-variables)
      for a list of additional build parameters you can specify.


### PR DESCRIPTION
## Description

- having `clang` in targets is making my `cmake` fail for some reason (see below)
- apparently neither of the targets is really needed for accelerate (works here™)

cmake output:
```
CMake Warning at CMakeLists.txt:101 (message):
  Using LLVM_ENABLE_PROJECTS=libcxx is deprecated now, please use
  -DLLVM_ENABLE_RUNTIMES=libcxx or see the instructions at
  https://libcxx.llvm.org/BuildingLibcxx.html for building the runtimes.


CMake Warning at CMakeLists.txt:101 (message):
  Using LLVM_ENABLE_PROJECTS=libcxxabi is deprecated now, please use
  -DLLVM_ENABLE_RUNTIMES=libcxxabi or see the instructions at
  https://libcxx.llvm.org/BuildingLibcxx.html for building the runtimes.


-- bolt project is disabled
-- clang project is enabled
CMake Error at CMakeLists.txt:148 (message):
  LLVM_ENABLE_PROJECTS requests clang but directory not found:
  /home/exa/work/llvm-15.0.7.src/../clang
```

I assume the warnings would be quenched by changing the option. `clang` build seems to require additional download to the llvm source (no idea how it came up with that path otherwise).

## How has this been tested?

quite manually on recently updated debian trixie

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

