### PR TITLE
add explicit dependency on libm to compiled .so

### DIFF
--- a/accelerate-llvm-native/src/Data/Array/Accelerate/LLVM/Native/Compile.hs
+++ b/accelerate-llvm-native/src/Data/Array/Accelerate/LLVM/Native/Compile.hs
@@ -159,7 +159,7 @@ compile pacc aenv = do
 #if defined(darwin_HOST_OS)
         callProcess ld ["--shared", "-o", sharedObjFile, objFile, "-undefined", "dynamic_lookup"]
 #else
-        callProcess ld ["--shared", "-o", sharedObjFile, objFile]
+        callProcess ld ["--shared", "-o", sharedObjFile, objFile, "-lm"]
 #endif
         Debug.traceM Debug.dump_cc ("cc: new shared object " % shown) uid
 


### PR DESCRIPTION
Without this, statically-built programs that use accelerate-llvm fail whenever a library primitive is used for evaluation. In my case it was any function that uses `expf`.

## Motivation and context

Without this, the created `.so` contains an undefined reference to `expf` which is supposed to be solved by the linker. With static executable, the `expf` is not really exposed (or even present!) there. Moreover, we should make sure we're actually using the `expf` from the target system in case someone moves the executable. This change declares it properly.

## How has this been tested?

Locally on 2 computers (moving the static binary between two different amd64 boxes (skylake and some older xeon)).

Any help with testing very welcome.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)  (**NOTE:** I hope this is not breaking.
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

